### PR TITLE
detect/report errors from the validator, fix false rule reporting

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -108,6 +108,7 @@ function lint(objectName, object, options = {}) {
             }
         }
     }
+    delete options.lintRule;
 }
 
 module.exports = {

--- a/lint.js
+++ b/lint.js
@@ -47,11 +47,17 @@ const lintResolvedSchema = (options) => {
 const formatLinterError = (err, context, rule) => {
   const pointer = context.pop();
   const message = err.message;
-  const output = `
+  let output;
+  if (rule) output = `
 ${colors['yellow'] + pointer} ${colors['cyan']} R: ${rule.name} ${colors['white']} D: ${rule.description}
 
 ${colors['reset'] + message}
   `
+  else {
+    output = `
+${colors['red'] + pointer} ${colors['reset'] + message }
+`;
+  }
 
   console.log(output);
 


### PR DESCRIPTION
When given invalid input (i.e. that which trips up the validator before the linter) speccy was barfing with a reference error to a non-existent rule.

We also clear down the last rule invoked in the linter to prevent validation errors wrongly being reported as linter errors.