### PR TITLE
Adding support for enforcing alphabeticalness of arrays.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -21,6 +21,7 @@ function deepMergeRules(ruleNickname, rules = []) {
       const rule = data['rules'][r];
       if (!rule.enabled) continue;
       if (!Array.isArray(rule.object)) rule.object = [ rule.object ];
+      if (rule.alphabetical && !Array.isArray(rule.alphabetical)) rule.alphabetical = [ rule.alphabetical ];
       if (rule.truthy && !Array.isArray(rule.truthy)) rule.truthy = [ rule.truthy ];
       rules.push(rule);
   }
@@ -51,6 +52,17 @@ function lint(objectName, object, options = {}) {
                 for (const property of rule.truthy) {
                     object.should.have.property(property);
                     object[property].should.not.be.empty();
+                }
+            }
+            if (rule.alphabetical) {
+                for (const property of rule.alphabetical) {
+                    if (object[property].length < 2) {
+                        continue;
+                    }
+
+                    let arrayCopy = object[property].slice(0);
+                    object.should.have.property(property);
+                    object[property].should.be.equal(arrayCopy)
                 }
             }
             if (rule.properties) {

--- a/rules/default.json
+++ b/rules/default.json
@@ -58,6 +58,13 @@
             "truthy": "tags"
         },
         {
+            "name": "openapi-tags-alphabetical",
+            "object": "openapi",
+            "enabled": true,
+            "description": "openapi object should have alphabetical tags",
+            "alphabetical": "tags"
+        },
+        {
             "name": "reference-no-other-properties",
             "object": "reference",
             "enabled": true,

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -47,6 +47,10 @@ describe('lint()', () => {
                         error: 'expected Array [] not to be empty (false negative fail)'
                     },
                     {
+                        input: { openapi: 3, tags: ['foo', 'bar'] },
+                        error: 'expected Array [ \'foo\', \'bar\' ] to be Array [ \'bar\', \'foo\' )'
+                    },
+                    {
                         input: { openapi: 3, tags: ['foo'] },
                         expectValid: true
                     }
@@ -87,6 +91,10 @@ describe('lint()', () => {
                     {
                         input: { openapi: 3, tags: [] },
                         error: 'expected Array [] not to be empty (false negative fail)'
+                    },
+                    {
+                        input: { openapi: 3, tags: ['foo', 'bar'] },
+                        error: 'expected Array [ \'foo\', \'bar\' ] to be Array [ \'bar\', \'foo\' )'
                     },
                     {
                         input: { openapi: 3, tags: ['foo'] },


### PR DESCRIPTION
This adds a new `alphabetical` rule that allows you to enforce arrays (eg. tags) to be alphabetical. It works the same way that `truthy` does in that you can either specify in your rule file `"alphabetical": "tags"` or `"alphabetical": ["tags"]`.

Thanks for a cool library!