### PR TITLE
Expanding alphabetical support to allow for alphabetizing objects.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -21,7 +21,9 @@ function deepMergeRules(ruleNickname, rules = []) {
       const rule = data['rules'][r];
       if (!rule.enabled) continue;
       if (!Array.isArray(rule.object)) rule.object = [ rule.object ];
-      if (rule.alphabetical && !Array.isArray(rule.alphabetical)) rule.alphabetical = [ rule.alphabetical ];
+      if (rule.alphabetical && rule.alphabetical.properties && !Array.isArray(rule.alphabetical.properties)) {
+          rule.alphabetical.properties = [ rule.alphabetical.properties ];
+      }
       if (rule.truthy && !Array.isArray(rule.truthy)) rule.truthy = [ rule.truthy ];
       rules.push(rule);
   }
@@ -40,7 +42,6 @@ function loadRules(loadFiles) {
 }
 
 function lint(objectName, object, options = {}) {
-
     for (const r in loadedRules) {
         const rule = loadedRules[r];
         if ((rule.object[0] === '*') || (rule.object.indexOf(objectName)>=0)) {
@@ -55,14 +56,30 @@ function lint(objectName, object, options = {}) {
                 }
             }
             if (rule.alphabetical) {
-                for (const property of rule.alphabetical) {
+                for (const property of rule.alphabetical.properties) {
                     if (object[property].length < 2) {
                         continue;
                     }
 
-                    let arrayCopy = object[property].slice(0);
+                    const arrayCopy = object[property].slice(0);
+
+                    // If we aren't expecting an object keyed by a specific property, then treat the
+                    // object as a simple array.
+                    if (!rule.alphabetical.keyedBy) {
+                        arrayCopy.sort()
+                    } else {
+                        const keyedBy = [rule.alphabetical.keyedBy];
+                        arrayCopy.sort(function (a, b) {
+                            if (a[keyedBy] < b[keyedBy]) {
+                                return -1;
+                            } else if (a[keyedBy] > b[keyedBy]) {
+                                return 1;
+                            }
+                        })
+                    }
+
                     object.should.have.property(property);
-                    object[property].should.be.equal(arrayCopy)
+                    object[property].should.be.equal(arrayCopy);
                 }
             }
             if (rule.properties) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -79,7 +79,7 @@ function lint(objectName, object, options = {}) {
                     }
 
                     object.should.have.property(property);
-                    object[property].should.be.equal(arrayCopy);
+                    object[property].should.be.deepEqual(arrayCopy);
                 }
             }
             if (rule.properties) {

--- a/rules/default.json
+++ b/rules/default.json
@@ -62,7 +62,10 @@
             "object": "openapi",
             "enabled": true,
             "description": "openapi object should have alphabetical tags",
-            "alphabetical": "tags"
+            "alphabetical": {
+                "properties": "tags",
+                "keyedBy": "name"
+            }
         },
         {
             "name": "reference-no-other-properties",

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -3,8 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const should = require('should');
-const yaml = require('js-yaml');
-
 const linter = require('../lib/linter.js');
 
 function testFixtures(fixtures) {
@@ -30,109 +28,15 @@ function testFixtures(fixtures) {
 }
 
 describe('lint()', () => {
+    const profilesDir = path.join(__dirname, './profiles/');
 
-    context('when default profile is loaded', () => {
-        linter.loadRules(['default']);
+    fs.readdirSync(profilesDir).forEach(function (file) {
+        const profile = JSON.parse(fs.readFileSync(profilesDir + file, 'utf8'))
+        const profileName = file.replace(path.extname(file), '')
 
-        const fixtures = [
-            {
-                object: 'openapi',
-                tests: [
-                    {
-                        input: { openapi: 3 },
-                        error: 'expected Object { openapi: 3 } to have property tags'
-                    },
-                    {
-                        input: { openapi: 3, tags: [] },
-                        error: 'expected Array [] not to be empty (false negative fail)'
-                    },
-                    {
-                        input: {
-                            openapi: 3,
-                            tags: [
-                                {name: 'foo'},
-                                {name: 'bar'}
-                            ]
-                        },
-                        error: 'expected Array [ Object { name: \'foo\' }, Object { name: \'bar\' } ] to be Array [ Object { name: \'bar\' }, Object { name: \'foo\' } ]'
-                    },
-                    {
-                        input: { openapi: 3, tags: [ {name: 'foo'} ] },
-                        expectValid: true
-                    }
-                ]
-            },
-            {
-                object: 'info',
-                tests: [
-                    {
-                        input: {},
-                        error: 'expected Object {} to have property contact'
-                    },
-                    {
-                        input: { contact: {} },
-                        error: 'expected Object {} not to be empty (false negative fail)'
-                    },
-                    {
-                        input: { contact: { foo: 'bar' } },
-                        expectValid: true
-                    }
-                ]
-            }
-        ];
-
-        testFixtures(fixtures);
-    });
-    context('when default profile is loaded', () => {
-        linter.loadRules(['default']);
-
-        const fixtures = [
-            {
-                object: 'openapi',
-                tests: [
-                    {
-                        input: { openapi: 3 },
-                        error: 'expected Object { openapi: 3 } to have property tags'
-                    },
-                    {
-                        input: { openapi: 3, tags: [] },
-                        error: 'expected Array [] not to be empty (false negative fail)'
-                    },
-                    {
-                        input: {
-                            openapi: 3,
-                            tags: [
-                                {name: 'foo'},
-                                {name: 'bar'}
-                            ]
-                        },
-                        error: 'expected Array [ Object { name: \'foo\' }, Object { name: \'bar\' } ] to be Array [ Object { name: \'bar\' }, Object { name: \'foo\' } ]'
-                    },
-                    {
-                        input: { openapi: 3, tags: ['foo'] },
-                        expectValid: true
-                    }
-                ]
-            },
-            {
-                object: 'info',
-                tests: [
-                    {
-                        input: {},
-                        error: 'expected Object {} to have property contact'
-                    },
-                    {
-                        input: { contact: {} },
-                        error: 'expected Object {} not to be empty (false negative fail)'
-                    },
-                    {
-                        input: { contact: { foo: 'bar' } },
-                        expectValid: true
-                    }
-                ]
-            }
-        ];
-
-        testFixtures(fixtures);
-    });
+        context('when `' + profileName + '` profile is loaded', () => {
+            linter.loadRules(profile.rules);
+            testFixtures(profile.fixtures);
+        })
+    })
 });

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -20,7 +20,7 @@ function testFixtures(fixtures) {
                 }
                 else {
                     it('throws error', (done) => {
-                        (() => linter.lint(object, test['input'])).should.throw(test['message']);
+                        (() => linter.lint(object, test['input'])).should.throw(test['error']);
                         done();
                     });
                 }
@@ -47,11 +47,17 @@ describe('lint()', () => {
                         error: 'expected Array [] not to be empty (false negative fail)'
                     },
                     {
-                        input: { openapi: 3, tags: ['foo', 'bar'] },
-                        error: 'expected Array [ \'foo\', \'bar\' ] to be Array [ \'bar\', \'foo\' )'
+                        input: {
+                            openapi: 3,
+                            tags: [
+                                {name: 'foo'},
+                                {name: 'bar'}
+                            ]
+                        },
+                        error: 'expected Array [ Object { name: \'foo\' }, Object { name: \'bar\' } ] to be Array [ Object { name: \'bar\' }, Object { name: \'foo\' } ]'
                     },
                     {
-                        input: { openapi: 3, tags: ['foo'] },
+                        input: { openapi: 3, tags: [ {name: 'foo'} ] },
                         expectValid: true
                     }
                 ]
@@ -61,7 +67,7 @@ describe('lint()', () => {
                 tests: [
                     {
                         input: {},
-                        error: 'expected Object {} not to be empty (false negative fail)'
+                        error: 'expected Object {} to have property contact'
                     },
                     {
                         input: { contact: {} },
@@ -93,8 +99,14 @@ describe('lint()', () => {
                         error: 'expected Array [] not to be empty (false negative fail)'
                     },
                     {
-                        input: { openapi: 3, tags: ['foo', 'bar'] },
-                        error: 'expected Array [ \'foo\', \'bar\' ] to be Array [ \'bar\', \'foo\' )'
+                        input: {
+                            openapi: 3,
+                            tags: [
+                                {name: 'foo'},
+                                {name: 'bar'}
+                            ]
+                        },
+                        error: 'expected Array [ Object { name: \'foo\' }, Object { name: \'bar\' } ] to be Array [ Object { name: \'bar\' }, Object { name: \'foo\' } ]'
                     },
                     {
                         input: { openapi: 3, tags: ['foo'] },
@@ -107,7 +119,7 @@ describe('lint()', () => {
                 tests: [
                     {
                         input: {},
-                        error: 'expected Object {} not to be empty (false negative fail)'
+                        error: 'expected Object {} to have property contact'
                     },
                     {
                         input: { contact: {} },

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -1,0 +1,51 @@
+{
+  "rules": [
+    "default"
+  ],
+  "fixtures": [
+    {
+      "object": "openapi",
+      "tests": [
+        {
+          "input": { "openapi": 3 },
+          "error": "expected Object { openapi: 3 } to have property tags"
+        },
+        {
+          "input": { "openapi": 3, "tags": [] },
+          "error": "expected Array [] not to be empty (false negative fail)"
+        },
+        {
+          "input": {
+            "openapi": 3,
+            "tags": [
+              {"name": "foo"},
+              {"name": "bar"}
+            ]
+          },
+          "error": "expected Array [ Object { name: 'foo' }, Object { name: 'bar' } ] to be Array [ Object { name: 'bar' }, Object { name: 'foo' } ]"
+        },
+        {
+          "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },
+          "expectValid": true
+        }
+      ]
+    },
+    {
+      "object": "info",
+      "tests": [
+        {
+          "input": {},
+          "error": "expected Object {} to have property contact"
+        },
+        {
+          "input": { "contact": {} },
+          "error": "expected Object {} not to be empty (false negative fail)"
+        },
+        {
+          "input": { "contact": { "foo": "bar" } },
+          "expectValid": true
+        }
+      ]
+    }
+  ]
+}

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -22,7 +22,7 @@
               {"name": "bar"}
             ]
           },
-          "error": "expected Array [ Object { name: 'foo' }, Object { name: 'bar' } ] to be Array [ Object { name: 'bar' }, Object { name: 'foo' } ]"
+          "error": "expected Array [ Object { name: 'foo' }, Object { name: 'bar' } ] to equal Array [ Object { name: 'bar' }, Object { name: 'foo' } ] (at '0' -> name, A has 'foo' and B has 'bar')"
         },
         {
           "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },


### PR DESCRIPTION
This does a few things:

* [ ] Slightly alters the format of the `alphabetical` rule I introduced in https://github.com/wework/speccy/pull/3 to allow for linting objects that you might want alphabetical.
* [ ] Splits out the linter fixtures into individual files for each profile. As it was, duplicate tests were happening for the same `default` profile.
* [ ] Fixed a few bugs in the linter test that was masking failing tests, and fixed those that were.