### PR TITLE
Add skip option for linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Ensure your OpenAPI files are valid and up to scratch
 Options:
 
     -r, --rules [ruleFile]  use this multiple times to select multiple rules files
+    -s, --skip [ruleName]   use this multiple times to skip specific rules
     -h, --help              output usage information
 ```
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -32,7 +32,7 @@ function deepMergeRules(ruleNickname, skipRules, rules = []) {
   return rules;
 }
 
-function loadRules(loadFiles, skipRules) {
+function loadRules(loadFiles, skipRules = []) {
     loadedRules = [];
 
     const files = (loadFiles.length > 0 ? loadFiles : ['default']);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -8,7 +8,7 @@ const should = require('should');
 let loadedRules;
 
 // TODO Eventually support more than just core files
-function deepMergeRules(ruleNickname, rules = []) {
+function deepMergeRules(ruleNickname, skipRules, rules = []) {
   const ruleFile = path.join(__dirname, '../rules/' + ruleNickname + '.json');
   const content = fs.readFileSync(ruleFile, 'utf8');
   const data = yaml.safeLoad(content, { json: true });
@@ -20,6 +20,7 @@ function deepMergeRules(ruleNickname, rules = []) {
   for (const r in data['rules']) {
       const rule = data['rules'][r];
       if (!rule.enabled) continue;
+      if (skipRules.indexOf(rule.name) !== -1) continue;
       if (!Array.isArray(rule.object)) rule.object = [ rule.object ];
       if (rule.alphabetical && rule.alphabetical.properties && !Array.isArray(rule.alphabetical.properties)) {
           rule.alphabetical.properties = [ rule.alphabetical.properties ];
@@ -31,13 +32,13 @@ function deepMergeRules(ruleNickname, rules = []) {
   return rules;
 }
 
-function loadRules(loadFiles) {
+function loadRules(loadFiles, skipRules) {
     loadedRules = [];
 
     const files = (loadFiles.length > 0 ? loadFiles : ['default']);
 
     for (const f in files) {
-        loadedRules = loadedRules.concat(deepMergeRules(files[f]));
+        loadedRules = loadedRules.concat(deepMergeRules(files[f], skipRules));
     }
 }
 

--- a/lint.js
+++ b/lint.js
@@ -76,7 +76,7 @@ const main = (str, callback) => {
 
 const command = (file, cmd) => {
 
-  linter.loadRules(cmd.rules);
+  linter.loadRules(cmd.rules, cmd.skip);
 
   if (file && file.startsWith('http')) {
       console.log('GET ' + file);

--- a/speccy.js
+++ b/speccy.js
@@ -22,6 +22,7 @@ program
 program
     .command('lint <file-or-url>')
     .option('-r, --rules [ruleFile]', 'Provide multiple rules files', collect, [])
+    .option('-s, --skip [ruleName]', 'Provide multiple rules to skip', collect, [])
     .action(lint.command);
 
 program

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -35,7 +35,7 @@ describe('lint()', () => {
         const profileName = file.replace(path.extname(file), '')
 
         context('when `' + profileName + '` profile is loaded', () => {
-            linter.loadRules(profile.rules);
+            linter.loadRules(profile.rules, profile.skip);
             testFixtures(profile.fixtures);
         })
     })

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -5,19 +5,22 @@ const path = require('path');
 const should = require('should');
 const linter = require('../lib/linter.js');
 
-function testFixtures(fixtures) {
-    fixtures.forEach((fixture) => {
+function testProfile(profile) {
+
+    profile.fixtures.forEach((fixture) => {
         const { object, tests } = fixture;
         describe('linting the ' + object + " object", () => {
             tests.forEach((test) => {
                 if (test.expectValid) {
                     it('is valid', (done) => {
+                        linter.loadRules(profile.rules, test.skip);
                         linter.lint(object, test['input']); // will not raise
                         done();
                     });
                 }
                 else {
                     it('throws error', (done) => {
+                        linter.loadRules(profile.rules, test.skip);
                         (() => linter.lint(object, test['input'])).should.throw(test['error']);
                         done();
                     });
@@ -35,8 +38,7 @@ describe('lint()', () => {
         const profileName = file.replace(path.extname(file), '')
 
         context('when `' + profileName + '` profile is loaded', () => {
-            linter.loadRules(profile.rules, profile.skip);
-            testFixtures(profile.fixtures);
+            testProfile(profile);
         })
     })
 });

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -26,6 +26,11 @@
           "error": "expected Array [ Object { name: 'foo' }, Object { name: 'bar' } ] to equal Array [ Object { name: 'bar' }, Object { name: 'foo' } ] (at '0' -> name, A has 'foo' and B has 'bar')"
         },
         {
+          "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
+          "skip": [ "openapi-tags-alphabetical" ],
+          "expectValid": true
+        },
+        {
           "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },
           "expectValid": true
         }
@@ -41,6 +46,11 @@
         {
           "input": { "contact": {} },
           "error": "expected Object {} not to be empty (false negative fail)"
+        },
+        {
+          "input": {},
+          "skip": [ "info-contact" ],
+          "expectValid": true
         },
         {
           "input": { "contact": { "foo": "bar" } },

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -2,6 +2,7 @@
   "rules": [
     "default"
   ],
+  "skip": [],
   "fixtures": [
     {
       "object": "openapi",


### PR DESCRIPTION
Added `--skip` option for linter to skip one or more rules by name from
linting.

Fixes #5