### PR TITLE
Linter show more than one rule

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -42,23 +42,43 @@ function loadRules(loadFiles, skipRules = []) {
     }
 }
 
+function ensureRule(context, rule, shouldAssertion, results) {
+    try {
+        shouldAssertion();
+    } catch (error) {
+        // rethrow when not a lint error
+        if (!error.name || error.name !== "AssertionError") throw error;
+
+        var pointer = (context && context.length>0 ? context[context.length-1] : null);
+        const result = { pointer, rule, error };
+        results.push(result);
+    }
+}
+
 function lint(objectName, object, options = {}) {
+
+    function ensure(rule, func) {
+        ensureRule(options.context, rule, func, options.lintResults);
+    }
+
     for (const r in loadedRules) {
         const rule = loadedRules[r];
         if ((rule.object[0] === '*') || (rule.object.indexOf(objectName)>=0)) {
-            options.lintRule = rule;
+
             if (rule.skip && options[rule.skip]) {
                 continue;
             }
             if (rule.truthy) {
                 for (const property of rule.truthy) {
-                    object.should.have.property(property);
-                    object[property].should.not.be.empty();
+                    ensure(rule, () => {
+                        object.should.have.property(property);
+                        object[property].should.not.be.empty();
+                    });
                 }
             }
             if (rule.alphabetical) {
                 for (const property of rule.alphabetical.properties) {
-                    if (object[property].length < 2) {
+                    if (!object[property] || object[property].length < 2) {
                         continue;
                     }
 
@@ -78,30 +98,41 @@ function lint(objectName, object, options = {}) {
                             }
                         })
                     }
-
-                    object.should.have.property(property);
-                    object[property].should.be.deepEqual(arrayCopy);
+                    ensure(rule, () => {
+                        object.should.have.property(property);
+                        object[property].should.be.deepEqual(arrayCopy);
+                    });
                 }
             }
             if (rule.properties) {
-                should(Object.keys(object).length).be.exactly(rule.properties);
+                ensure(rule, () => {
+                    should(Object.keys(object).length).be.exactly(rule.properties);
+                });
             }
             if (rule.or) {
                 let found = false;
                 for (const property of rule.or) {
                     if (typeof object[property] !== 'undefined') found = true;
                 }
-                found.should.be.exactly(true,rule.description);
+                ensure(rule, () => {
+                    found.should.be.exactly(true,rule.description);
+                });
             }
             if (rule.xor) {
                 let found = false;
                 for (const property of rule.xor) {
                     if (typeof object[property] !== 'undefined') {
-                        if (found) should.fail(true,false,rule.description);
+                        if (found) {
+                            ensure(rule, () => {
+                                should.fail(true,false,rule.description);
+                            });
+                        }
                         found = true;
                     }
                 }
-                found.should.be.exactly(true,rule.description);
+                ensure(rule, () => {
+                    found.should.be.exactly(true,rule.description);
+                });
             }
             if (rule.pattern) {
                 let components = [];
@@ -115,7 +146,9 @@ function lint(objectName, object, options = {}) {
                 for (let component of components) {
                     if (rule.pattern.omit) component = component.split(rule.pattern.omit).join('');
                     if (component) {
-                        should(re.test(component)).be.exactly(true,rule.description);
+                        ensure(rule, () => {
+                            should(re.test(component)).be.exactly(true,rule.description);
+                        });
                     }
                 }
             }
@@ -123,22 +156,27 @@ function lint(objectName, object, options = {}) {
                 for (const property of rule.notContain.properties) {
                     if (object[property] && (typeof object[property] === 'string') &&
                         (object[property].indexOf(rule.notContain.value)>=0)) {
-                        should.fail(true,false,rule.description);
+                            ensure(rule, () => {
+                                should.fail(true,false,rule.description);
+                            });
                     }
                 }
             }
             if (rule.notEndWith) {
-                should(object[rule.notEndWith.property]).not.endWith(rule.notEndWith.value)
+                ensure(rule, () => {
+                    should(object[rule.notEndWith.property]).not.endWith(rule.notEndWith.value)
+                });
             }
             if (rule.maxLength) {
                 const { value, property } = rule.maxLength;
                 if (object[property] && (typeof object[property] === 'string')) {
-                    object.should.have.property(property).with.lengthOf(value);
+                    ensure(rule, () => {
+                        object.should.have.property(property).with.lengthOf(value);
+                    });
                 }
             }
         }
     }
-    delete options.lintRule;
 }
 
 module.exports = {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1199,6 +1199,7 @@ function setupOptions(options,openapi) {
     options.operationIds = [];
     options.openapi = openapi;
     options.linter = linter.lint;
+    options.lintResults = [];
 }
 
 function validate(openapi, options, callback) {

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -11,17 +11,19 @@ function testProfile(profile) {
         const { object, tests } = fixture;
         describe('linting the ' + object + " object", () => {
             tests.forEach((test) => {
+                var options = {lintResults: []};
                 if (test.expectValid) {
                     it('is valid', (done) => {
                         linter.loadRules(profile.rules, test.skip);
-                        linter.lint(object, test['input']); // will not raise
+                        linter.lint(object, test['input'], options);
+                        options.lintResults.should.be.empty();
                         done();
-                    });
-                }
-                else {
-                    it('throws error', (done) => {
+                });
+                } else {
+                    it('is not valid', (done) => {
                         linter.loadRules(profile.rules, test.skip);
-                        (() => linter.lint(object, test['input'])).should.throw(test['error']);
+                        linter.lint(object, test['input'], options);
+                        options.lintResults.should.not.be.empty();
                         done();
                     });
                 }

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -11,19 +11,19 @@ function testProfile(profile) {
         const { object, tests } = fixture;
         describe('linting the ' + object + " object", () => {
             tests.forEach((test) => {
-                var options = {lintResults: []};
+                var options = { lintResults : []};
+                linter.loadRules(profile.rules, test.skip);
+                linter.lint(object, test['input'], options);
+
                 if (test.expectValid) {
                     it('is valid', (done) => {
-                        linter.loadRules(profile.rules, test.skip);
-                        linter.lint(object, test['input'], options);
                         options.lintResults.should.be.empty();
                         done();
-                });
+                    });
                 } else {
                     it('is not valid', (done) => {
-                        linter.loadRules(profile.rules, test.skip);
-                        linter.lint(object, test['input'], options);
-                        options.lintResults.should.not.be.empty();
+                        const actualRuleErrors = options.lintResults.map(result => result.rule.name);
+                        test.expectedRuleErrors.should.deepEqual(actualRuleErrors);
                         done();
                     });
                 }

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -2,28 +2,21 @@
   "rules": [
     "default"
   ],
-  "skip": [],
   "fixtures": [
     {
       "object": "openapi",
       "tests": [
         {
           "input": { "openapi": 3 },
-          "error": "expected Object { openapi: 3 } to have property tags"
+          "expectedRuleErrors" : ["openapi-tags"]
         },
         {
           "input": { "openapi": 3, "tags": [] },
-          "error": "expected Array [] not to be empty (false negative fail)"
+          "expectedRuleErrors" : ["openapi-tags"]
         },
         {
-          "input": {
-            "openapi": 3,
-            "tags": [
-              {"name": "foo"},
-              {"name": "bar"}
-            ]
-          },
-          "error": "expected Array [ Object { name: 'foo' }, Object { name: 'bar' } ] to equal Array [ Object { name: 'bar' }, Object { name: 'foo' } ] (at '0' -> name, A has 'foo' and B has 'bar')"
+          "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
+          "expectedRuleErrors" : ["openapi-tags-alphabetical"]
         },
         {
           "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
@@ -41,11 +34,11 @@
       "tests": [
         {
           "input": {},
-          "error": "expected Object {} to have property contact"
+          "expectedRuleErrors" : ["info-contact"]
         },
         {
           "input": { "contact": {} },
-          "error": "expected Object {} not to be empty (false negative fail)"
+          "expectedRuleErrors" : ["info-contact"]
         },
         {
           "input": {},


### PR DESCRIPTION
Updated to collect lint errors and return all instead of just the first one. 

Stopped the `should` exceptions from bubbling up, these are collected along with the specific rule that failed and other relevant context info. These results get returned as a new options property `lintResults`.

Let me know if you wanted anything changed up. The schema validation will still only return the first error, but that could be handled in another issue following a similar pattern.

Fixes #6