### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2018-02-26
+### Added
+- Added `--skip` to lint command to allow certain rules to be skipped ([#9] via @jblazek)
+- CLI output shows all lint errors, not just the first error found ([#11] via @jblazek)
+
+[#9]: https://github.com/wework/speccy/pull/9
+[#11]: https://github.com/wework/speccy/pull/11
+
 ## [0.3.1] - 2018-02-15
 ### Added
 - Fixed `serve` command when package is installed via yarn global

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Your friendly OpenAPI v3.0 #WellActually CLI assistant.",
   "bin": {
     "speccy": "./speccy.js"


### PR DESCRIPTION

![screen shot 2018-02-26 at 11 02 22 am](https://user-images.githubusercontent.com/67381/36681176-e32ebd78-1ae5-11e8-96e2-4dd2cecfef99.png)

### Added
- Added `--skip` to lint command to allow certain rules to be skipped ([#9] via @jblazek)
- CLI output shows all lint errors, not just the first error found ([#11] via @jblazek)

[#9]: https://github.com/wework/speccy/pull/9
[#11]: https://github.com/wework/speccy/pull/11