### PR TITLE
PathItem $ref was considered invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Path Item `$ref` support fixed ([#16])
+
+[#16]: https://github.com/wework/speccy/pull/16
+
 ## [0.4.0] - 2018-02-26
 ### Added
 - Added `--skip` to lint command to allow certain rules to be skipped ([#9] via @jblazek)

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -13,19 +13,19 @@ function deepMergeRules(ruleNickname, skipRules, rules = []) {
   const content = fs.readFileSync(ruleFile, 'utf8');
   const data = yaml.safeLoad(content, { json: true });
 
-  if (typeof data['require'] == 'string') {
-      rules = deepMergeRules(data['require'], rules);
+  if (typeof data.require == 'string') {
+      rules = deepMergeRules(data.require, rules);
   }
 
-  for (const r in data['rules']) {
-      const rule = data['rules'][r];
+  for (const r in data.rules) {
+      const rule = data.rules[r];
       if (!rule.enabled) continue;
       if (skipRules.indexOf(rule.name) !== -1) continue;
-      if (!Array.isArray(rule.object)) rule.object = [ rule.object ];
+      if (!Array.isArray(rule.object)) rule.object = [rule.object];
       if (rule.alphabetical && rule.alphabetical.properties && !Array.isArray(rule.alphabetical.properties)) {
-          rule.alphabetical.properties = [ rule.alphabetical.properties ];
+          rule.alphabetical.properties = [rule.alphabetical.properties];
       }
-      if (rule.truthy && !Array.isArray(rule.truthy)) rule.truthy = [ rule.truthy ];
+      if (rule.truthy && !Array.isArray(rule.truthy)) rule.truthy = [rule.truthy];
       rules.push(rule);
   }
 
@@ -45,11 +45,12 @@ function loadRules(loadFiles, skipRules = []) {
 function ensureRule(context, rule, shouldAssertion, results) {
     try {
         shouldAssertion();
-    } catch (error) {
+    }
+    catch (error) {
         // rethrow when not a lint error
         if (!error.name || error.name !== "AssertionError") throw error;
 
-        var pointer = (context && context.length>0 ? context[context.length-1] : null);
+        const pointer = (context && context.length > 0 ? context[context.length-1] : null);
         const result = { pointer, rule, error };
         results.push(result);
     }
@@ -86,17 +87,20 @@ function lint(objectName, object, options = {}) {
 
                     // If we aren't expecting an object keyed by a specific property, then treat the
                     // object as a simple array.
-                    if (!rule.alphabetical.keyedBy) {
-                        arrayCopy.sort()
-                    } else {
+                    if (rule.alphabetical.keyedBy) {
                         const keyedBy = [rule.alphabetical.keyedBy];
                         arrayCopy.sort(function (a, b) {
                             if (a[keyedBy] < b[keyedBy]) {
                                 return -1;
-                            } else if (a[keyedBy] > b[keyedBy]) {
+                            }
+                            else if (a[keyedBy] > b[keyedBy]) {
                                 return 1;
                             }
-                        })
+                            return 0;
+                        });
+                    }
+                    else {
+                        arrayCopy.sort()
                     }
                     ensure(rule, () => {
                         object.should.have.property(property);
@@ -135,27 +139,31 @@ function lint(objectName, object, options = {}) {
                 });
             }
             if (rule.pattern) {
+                const { omit, property, split, value } = rule.pattern;
+                const target = object[property]
+
                 let components = [];
-                if (rule.pattern.split) {
-                    components = object[rule.pattern.property].split(rule.pattern.split);
+                if (split) {
+                    components = target.split(split);
                 }
                 else {
-                    components.push(object[rule.pattern.property]);
+                    components.push(target);
                 }
-                const re = new RegExp(rule.pattern.value);
+                const re = new RegExp(value);
                 for (let component of components) {
-                    if (rule.pattern.omit) component = component.split(rule.pattern.omit).join('');
+                    if (omit) component = component.split(omit).join('');
                     if (component) {
                         ensure(rule, () => {
-                            should(re.test(component)).be.exactly(true,rule.description);
+                            should(re.test(component)).be.exactly(true, rule.description);
                         });
                     }
                 }
             }
             if (rule.notContain) {
-                for (const property of rule.notContain.properties) {
+                const { value, properties } = rule.notContain;
+                for (const property of properties) {
                     if (object[property] && (typeof object[property] === 'string') &&
-                        (object[property].indexOf(rule.notContain.value)>=0)) {
+                        (object[property].indexOf(value) >= 0)) {
                             ensure(rule, () => {
                                 should.fail(true,false,rule.description);
                             });
@@ -163,8 +171,9 @@ function lint(objectName, object, options = {}) {
                 }
             }
             if (rule.notEndWith) {
+                const { value, property } = rule.notEndWith;
                 ensure(rule, () => {
-                    should(object[rule.notEndWith.property]).not.endWith(rule.notEndWith.value)
+                    should(object[property]).not.endWith(value)
                 });
             }
             if (rule.maxLength) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -130,7 +130,7 @@ function checkSubSchema(schema, parent, state) {
     }
     if (schema.pattern) {
         try {
-            let regex = new RegExp(schema.pattern);
+            const _ = new RegExp(schema.pattern);
         }
         catch (ex) {
             should.fail(false,true,'pattern does not conform to ECMA-262');
@@ -315,7 +315,9 @@ function checkExample(ex, contextServers, openapi, options) {
     //}
     if (typeof ex.externalValue !== 'undefined') {
         ex.should.not.have.property('value');
-        should.doesNotThrow(function () { validateUrl(ex.externalValue, contextServers, 'examples..externalValue', options) },'Invalid examples..externalValue');
+        should.doesNotThrow(function () {
+            validateUrl(ex.externalValue, contextServers, 'examples..externalValue', options);
+        },'Invalid examples..externalValue');
     }
     //else { // not mandated by the spec. moved to linter rule
     //    ex.should.have.property('value');
@@ -636,7 +638,7 @@ function checkPathItem(pathItem, path, openapi, options) {
 
     let pathParameters = {};
     if (typeof pathItem.parameters !== 'undefined') should(pathItem.parameters).be.an.Array();
-    for (let p in pathItem.parameters) {
+    for (const p in pathItem.parameters) {
         contextAppend(options, 'parameters');
         let param = checkParam(pathItem.parameters[p], p, path, contextServers, openapi, options);
         if (pathParameters[param.in+':'+param.name]) {
@@ -648,14 +650,14 @@ function checkPathItem(pathItem, path, openapi, options) {
         options.context.pop();
     }
 
-    for (let o in pathItem) {
+    for (const o in pathItem) {
         contextAppend(options, o);
         var op = pathItem[o];
         if (o === '$ref') {
             should(op).be.ok();
             op.should.have.type('string');
             should(op.startsWith('#/')).equal(false,'PathItem $refs must be external ('+op+')');
-            options.linter('reference',op,options);
+            options.linter('reference', pathItem, options);
         }
         else if (o === 'parameters') {
             // checked above

--- a/lint.js
+++ b/lint.js
@@ -44,7 +44,7 @@ const lintResolvedSchema = options => {
             return;
         }
 
-        console.log(colors.green + 'Specification is valid' + colors.reset)
+        console.log(colors.green + 'Specification is valid, with 0 lint errors' + colors.reset)
         process.exitCode = 0;
     });
 };

--- a/resolve.js
+++ b/resolve.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const util = require('util');
+'use strict';
 
+const fs = require('fs');
 const yaml = require('js-yaml');
 const fetch = require('node-fetch');
 

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -7,21 +7,22 @@ const linter = require('../lib/linter.js');
 
 function testProfile(profile) {
 
-    profile.fixtures.forEach((fixture) => {
+    profile.fixtures.forEach(fixture => {
         const { object, tests } = fixture;
         describe('linting the ' + object + " object", () => {
-            tests.forEach((test) => {
+            tests.forEach(test => {
                 var options = { lintResults : []};
                 linter.loadRules(profile.rules, test.skip);
-                linter.lint(object, test['input'], options);
+                linter.lint(object, test.input, options);
 
                 if (test.expectValid) {
-                    it('is valid', (done) => {
+                    it(JSON.stringify(test.input) + ' is valid', done => {
                         options.lintResults.should.be.empty();
                         done();
                     });
-                } else {
-                    it('is not valid', (done) => {
+                }
+                else {
+                    it(JSON.stringify(test.input) + ' is not valid', done => {
                         const actualRuleErrors = options.lintResults.map(result => result.rule.name);
                         test.expectedRuleErrors.should.deepEqual(actualRuleErrors);
                         done();

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -50,6 +50,24 @@
           "expectValid": true
         }
       ]
+    },
+    {
+      "object": "reference",
+      "tests": [
+        {
+          "input": {
+              "$ref": "./foo.yml"
+          },
+          "expectValid": true
+      },
+        {
+          "input": {
+              "$ref": "./foo.yml",
+              "something": "else"
+          },
+          "expectedRuleErrors": ["reference-no-other-properties"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The wrong item was being passed in as `reference` so it was breaking the `reference-components-regex` rule.

Did a little boyscouting on random style stuff (sorry not sorry) and also improved test output.

```

  lint()
    when `default` profile is loaded
      linting the openapi object
        ✓ {"openapi":3} is not valid
        ✓ {"openapi":3,"tags":[]} is not valid
        ✓ {"openapi":3,"tags":[{"name":"foo"},{"name":"bar"}]} is not valid
        ✓ {"openapi":3,"tags":[{"name":"foo"},{"name":"bar"}]} is valid
        ✓ {"openapi":3,"tags":[{"name":"foo"}]} is valid
      linting the info object
        ✓ {} is not valid
        ✓ {"contact":{}} is not valid
        ✓ {} is valid
        ✓ {"contact":{"foo":"bar"}} is valid
      linting the reference object
        ✓ {"$ref":"./foo.yml"} is valid
        ✓ {"$ref":"./foo.yml","something":"else"} is not valid
```