### PR TITLE
Fixing resolve logic in serve and lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - "stable"
+    - 9
     - 8
     - 7
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "stable"
     - 8
-    - 6
+    - 7
 before_script:
     - . ./bin/setflags.sh
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-03-09
+### Breaking Changes
+- Dropped support for NodeJS 6, now requires 7.5 (with `--harmony`) or higher.
+### Fixed
+- Linter was not resolving $ref properly, meaning more errors will now appear in $ref schemas ([#19])
+### Added
+- Serve command now supports URLs ([#19])
+
+[#19]: https://github.com/wework/speccy/pull/19
+
 ## [0.4.1] - 2018-03-07
 ### Fixed
-- Path Item `$ref` support fixed ([#16])
+- Path Item `$ref` support fixed in validator ([#16])
 - Serve command early exists and errors if file is not found, even added some tests ([#17])
 
 [#16]: https://github.com/wework/speccy/pull/16

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,13 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const url = require('url');
-
-const fetch = require('node-fetch');
-const yaml = require('js-yaml');
 const recurse = require('reftools/lib/recurse.js').recurse;
-const jptr = require('reftools/lib/jptr.js').jptr;
-const resolveInternal = jptr;
+const resolveInternal = require('reftools/lib/jptr.js').jptr;
 const clone = require('reftools/lib/clone.js').clone;
 
 function hasDuplicates(array) {
@@ -53,7 +47,7 @@ module.exports = {
     clone,
     hasDuplicates,
     recurse,
-    resolveInternal: jptr,
+    resolveInternal,
     parameterTypeProperties,
     httpVerbs,
     isRef

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const fs = require('fs');
+const fetch = require('node-fetch');
+const yaml = require('js-yaml');
+const resolver = require('./resolver.js');
+
+class ExtendableError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+class OpenError extends ExtendableError {}
+class ReadError extends ExtendableError {}
+
+function readFileAsync(filename, encoding) {
+    return new Promise(function (resolve, reject) {
+        fs.readFile(filename, encoding, function (err, data) {
+            if (err)
+                reject(err);
+            else
+                resolve(data);
+        });
+    });
+}
+
+function readSpecFile(file) {
+    if (file && file.startsWith('http')) {
+        return fetch(file).then(function (res) {
+            if (res.status !== 200) throw new Error(`Received status code ${res.status}`);
+            return res.text();
+        }).catch(err => { throw new OpenError(err.message) });
+    }
+    else {
+        return readFileAsync(file, 'utf8')
+            .then(data => {
+                return data;
+            })
+            .catch(err => { throw new OpenError(err.message) });
+    }
+}
+
+const resolveContent = (openapi, source) => {
+    const options = {
+        resolve: true,
+        cache: [],
+        externals: [],
+        externalRefs: {},
+        rewriteRefs: true,
+        origin: source,
+        source: source
+    };
+
+    options.openapi = openapi;
+
+    return resolver.resolve(options);
+        // .then(() => {
+        //     // console.log(options.openapi, 'resolved')
+        //     return options.openapi;
+        // })
+        // .catch(err => { throw err });
+}
+
+const loadSpec = async (source, opts = {}) => {
+    const { resolve = false } = opts;
+
+    const foo = await readSpecFile(source)
+        .then(content => {
+            return yaml.load(content, { json: true });
+        }, err => { throw new ReadError(e.message) })
+        .then(async unresolved => {
+            let resolved = unresolved;
+
+            if (resolve === true) {
+                resolved = (await resolveContent(unresolved, source)).openapi;
+            }
+            // console.log('json', JSON.stringify(resolved))
+
+            return resolved;
+        });
+
+    return foo;
+}
+
+module.exports = { loadSpec };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -16,8 +16,8 @@ class OpenError extends ExtendableError {}
 class ReadError extends ExtendableError {}
 
 function readFileAsync(filename, encoding) {
-    return new Promise(function (resolve, reject) {
-        fs.readFile(filename, encoding, function (err, data) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(filename, encoding, (err, data) => {
             if (err)
                 reject(err);
             else
@@ -28,17 +28,15 @@ function readFileAsync(filename, encoding) {
 
 function readSpecFile(file) {
     if (file && file.startsWith('http')) {
-        return fetch(file).then(function (res) {
-            if (res.status !== 200) throw new Error(`Received status code ${res.status}`);
+        return fetch(file).then(res => {
+            if (res.status !== 200) {
+                throw new Error(`Received status code ${res.status}`);
+            }
             return res.text();
-        }).catch(err => { throw new OpenError(err.message) });
+        })
     }
     else {
-        return readFileAsync(file, 'utf8')
-            .then(data => {
-                return data;
-            })
-            .catch(err => { throw new OpenError(err.message) });
+        return readFileAsync(file, 'utf8').then(data => data);
     }
 }
 
@@ -56,32 +54,27 @@ const resolveContent = (openapi, source) => {
     options.openapi = openapi;
 
     return resolver.resolve(options);
-        // .then(() => {
-        //     // console.log(options.openapi, 'resolved')
-        //     return options.openapi;
-        // })
-        // .catch(err => { throw err });
 }
 
 const loadSpec = async (source, opts = {}) => {
     const { resolve = false } = opts;
 
-    const foo = await readSpecFile(source)
+    return await readSpecFile(source)
         .then(content => {
-            return yaml.load(content, { json: true });
-        }, err => { throw new ReadError(e.message) })
+            try {
+                return yaml.load(content, { json: true });
+            }
+            catch (err) {
+                throw new ReadError(err.message);
+            }
+        }, err => { throw new OpenError(err.message) })
         .then(async unresolved => {
             let resolved = unresolved;
-
             if (resolve === true) {
                 resolved = (await resolveContent(unresolved, source)).openapi;
             }
-            // console.log('json', JSON.stringify(resolved))
-
             return resolved;
-        });
-
-    return foo;
+        }, err => { throw err });
 }
 
 module.exports = { loadSpec };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,15 +1,10 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const url = require('url');
-const util = require('util');
-
 const fetch = require('node-fetch');
 const yaml = require('js-yaml');
-
 const jptr = require('reftools/lib/jptr.js').jptr;
-
 const common = require('./common.js');
 
 const red = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[31m';
@@ -18,7 +13,7 @@ const yellow = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[33;1m';
 const normal = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[0m';
 
 function unique(arr) {
-    return [... new Set(arr)];
+    return [...new Set(arr)];
 }
 
 function readFileAsync(filename, encoding) {
@@ -47,6 +42,7 @@ function resolveAllInternal(obj, context, src, parentPath, base, options) {
                     if (!seen[obj[key]] && !obj.$fixed) {
                         let target = common.clone(jptr(context, obj[key]));
                         if (options.verbose>1) console.log((target === false ? red : green)+'Internal resolution', obj[key], normal);
+
                         /*
                             ResolutionCase:A is where there is a local reference in an externally
                             referenced document, and we have not seen it before. The reference
@@ -92,7 +88,7 @@ function resolveAllInternal(obj, context, src, parentPath, base, options) {
         });
     }
 
-    common.recurse(obj,{},function(obj,key,state){
+    common.recurse(obj,{},function(obj,key){
         if (common.isRef(obj, key)) {
             if (obj.$fixed) delete obj.$fixed;
         };
@@ -183,7 +179,7 @@ function resolveExternal(root, pointer, options, callback) {
         return readFileAsync(target, options.encoding || 'utf8')
             .then(function (data) {
                 try {
-                    let context = yaml.safeLoad(data, { json: true });
+                    const context = yaml.safeLoad(data, { json: true });
                     data = context;
                     /*
                         resolutionSource:C from a file, data is fresh but we clone it into the cache
@@ -334,7 +330,7 @@ const serial = funcs =>
     funcs.reduce((promise, func) =>
         promise.then(result => func().then(Array.prototype.concat.bind(result))), Promise.resolve([]));
 
-function loopReferences(options, res, rej) {
+const loopReferences = (options, res, rej) => {
     options.resolver.actions.push([]);
     findExternalRefs(options)
         .then(function (data) {
@@ -365,7 +361,7 @@ function loopReferences(options, res, rej) {
         });
 }
 
-function resolve(options) {
+const resolve = options => {
     options.resolver = {};
     options.resolver.depth = 0;
     options.resolver.base = options.source;
@@ -378,6 +374,4 @@ function resolve(options) {
     });
 }
 
-module.exports = {
-    resolve: resolve
-};
+module.exports = { resolve };

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,35 +2,7 @@
 
 const ejs = require('ejs');
 const fs = require('fs');
-const yaml = require('js-yaml');
 const path = require('path');
-
-class ExtendableError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = this.constructor.name;
-  }
-}
-
-class OpenError extends ExtendableError {}
-class ReadError extends ExtendableError {}
-
-function loadSpec(path) {
-    let fileContents, yml;
-    try {
-        fileContents = fs.readFileSync(path, 'utf8');
-    }
-    catch (e) {
-        throw new OpenError(e.message);
-    }
-    try {
-        yml = yaml.load(fileContents);
-    }
-    catch (e) {
-        throw new ReadError(e.message);
-    }
-    return JSON.stringify(yml);
-}
 
 function loadHTML(file) {
     try {
@@ -44,7 +16,4 @@ function loadHTML(file) {
     }
 }
 
-module.exports = {
-    loadSpec,
-    loadHTML
-};
+module.exports = { loadHTML };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -498,11 +498,7 @@ function checkResponse(response, contextServers, openapi, options) {
     response.should.have.property('description');
     should(response.description).have.type('string', 'response description should be of type string');
     response.should.not.have.property('examples');
-    if (typeof response.schema !== 'undefined') {
-        response.schema.should.be.an.Object();
-        response.schema.should.not.be.an.Array();
-        checkSchema(contentType.schema,{},'schema',openapi,options);
-    }
+    response.should.not.have.property('schema', 'response schema must go inside `content` and be listed under a mime type');
     if (response.headers) {
         contextAppend(options, 'headers');
         for (let h in response.headers) {

--- a/lint.js
+++ b/lint.js
@@ -22,15 +22,15 @@ const formatSchemaError = (err, context) => {
   const message = err.message;
   let output;
 
-    output = `
-${colors.red + pointer} ${colors.reset + message}
+  output = `
+${colors.yellow + pointer}
+${colors.reset + message}
 `;
 
-  console.log(output);
-
   if (err.stack && err.name !== 'AssertionError') {
-      console.log(colors.red + err.stack + colors.reset);
+      output += colors.red + err.stack + colors.reset;
   }
+  return output;
 }
 
 const formatLintResults = lintResults => {
@@ -43,9 +43,9 @@ ${colors.yellow + pointer} ${colors.cyan} R: ${rule.name} ${colors.white} D: ${r
 ${colors.reset + error.message}
 `;
     });
-    console.log(output);
-}
 
+    return output;
+}
 
 const readOrError = file => {
     try {
@@ -71,18 +71,20 @@ const command = async (file, cmd) => {
 
   linter.loadRules(cmd.rules, cmd.skip);
 
-  validator.validate(options.openapi, options, function(err, options) {
+  validator.validate(options.openapi, options, (err, options) => {
       if (err) {
-          console.log(colors.red + 'Specification schema is invalid.' + colors.reset);
-          formatSchemaError(err, options.context);
+          console.error(colors.red + 'Specification schema is invalid.' + colors.reset);
+          const output = formatSchemaError(err, options.context);
+          console.error(output);
           process.exit(1);
       }
 
       const lintResults = options.lintResults;
       if (lintResults.length) {
-          console.log(colors.red + 'Specification contains lint errors: ' + lintResults.length + colors.reset);
-          formatLintResults(lintResults);
-          process.exit(lintResults.length);
+          console.error(colors.red + 'Specification contains lint errors: ' + lintResults.length + colors.reset);
+          const output = formatLintResults(lintResults);
+          console.warn(output)
+          process.exit(1);
       }
 
       console.log(colors.green + 'Specification is valid, with 0 lint errors' + colors.reset)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Your friendly OpenAPI v3.0 #WellActually CLI assistant.",
   "bin": {
     "speccy": "./speccy.js"

--- a/resolve.js
+++ b/resolve.js
@@ -8,21 +8,6 @@ const fetch = require('node-fetch');
 
 const resolver = require('./lib/resolver.js');
 
-const main = (str, output) => {
-    options.openapi = yaml.safeLoad(str,{json:true});
-    resolver.resolve(options)
-    .then(function(){
-        options.status = 'resolved';
-        fs.writeFileSync(output, yaml.safeDump(options.openapi,{lineWidth:-1}),'utf8');
-        console.log('Resolved to ' + output);
-        process.exitCode = 0;
-    })
-    .catch(function(err){
-        options.status = 'rejected';
-        console.warn(err);
-    });
-};
-
 const options = {
     resolve: true,
     cache: [],
@@ -30,6 +15,21 @@ const options = {
     externalRefs: {},
     rewriteRefs: true,
     status: 'undefined',
+};
+
+const main = (str, output) => {
+    options.openapi = yaml.safeLoad(str,{json:true});
+    resolver.resolve(options)
+    .then(function(){
+        options.status = 'resolved';
+        fs.writeFileSync(output, yaml.safeDump(options.openapi,{lineWidth:-1}),'utf8');
+        console.log('Resolved to ' + output);
+        process.exit(0);
+    })
+    .catch(function(err){
+        options.status = 'rejected';
+        console.warn(err);
+    });
 };
 
 const command = (filespec, cmd) => {

--- a/speccy.js
+++ b/speccy.js
@@ -33,7 +33,7 @@ program
     .action(resolve.command);
 
 program
-    .command('serve <file>')
+    .command('serve <file-or-url>')
     .description('View specifications in beautiful human readable documentation')
     .option('-p, --port [value]', 'port on which the server will listen', 5000)
     .option('-w, --watch', 'reloding browser on spec file changes')

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const should = require('should');
 const linter = require('../lib/linter.js');
 
 function testProfile(profile) {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const path = require('path');
+const yaml = require('js-yaml');
+const loader = require('../lib/loader.js');
+
+describe('loadSpec()', () => {
+    const samplesDir = path.join(__dirname, './samples/');
+
+    it('loads test/samples/openapi.json', () => {
+        const spec = loader.loadSpec(samplesDir + 'openapi.json');
+        should(spec).have.key('openapi');
+    });
+
+    it('loads test/samples/openapi.json with resolver', () => {
+        const spec = loader.loadSpec(samplesDir + 'openapi.json', { resolve: true });
+        should(spec).have.key('openapi');
+    });
+
+    it('loads test/samples/openapi.yaml', () => {
+        const spec = loader.loadSpec(samplesDir + 'openapi.yaml');
+        should(spec).have.key('openapi');
+    });
+
+    it('throws OpenError for test/samples/nope.yaml', () => {
+        let thrownError;
+        try {
+            loader.loadSpec(samplesDir + 'nope.yaml');
+        }
+        catch (error) {
+            thrownError = error;
+        }
+        should(thrownError.name).equal('OpenError');
+    });
+
+    it('throws OpenError for test/samples/not-openapi.csv', () => {
+        let thrownError;
+        try {
+            loader.loadSpec(samplesDir + 'not-openapi.txt');
+        }
+        catch (error) {
+            thrownError = error;
+        }
+        should(thrownError.name).equal('ReadError');
+    });
+});

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -1,73 +1,106 @@
 {
-  "rules": [
-    "default"
-  ],
-  "fixtures": [
-    {
-      "object": "openapi",
-      "tests": [
+    "rules": [
+        "default"
+    ],
+    "fixtures": [
         {
-          "input": { "openapi": 3 },
-          "expectedRuleErrors" : ["openapi-tags"]
+            "object": "openapi",
+            "tests": [
+                {
+                    "input": { "openapi": 3 },
+                    "expectedRuleErrors" : ["openapi-tags"]
+                },
+                {
+                    "input": { "openapi": 3, "tags": [] },
+                    "expectedRuleErrors" : ["openapi-tags"]
+                },
+                {
+                    "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
+                    "expectedRuleErrors" : ["openapi-tags-alphabetical"]
+                },
+                {
+                    "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
+                    "skip": [ "openapi-tags-alphabetical" ],
+                    "expectValid": true
+                },
+                {
+                    "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },
+                    "expectValid": true
+                }
+            ]
         },
         {
-          "input": { "openapi": 3, "tags": [] },
-          "expectedRuleErrors" : ["openapi-tags"]
+            "object": "info",
+            "tests": [
+                {
+                    "input": {},
+                    "expectedRuleErrors" : ["info-contact"]
+                },
+                {
+                    "input": { "contact": {} },
+                    "expectedRuleErrors" : ["info-contact"]
+                },
+                {
+                    "input": {},
+                    "skip": [ "info-contact" ],
+                    "expectValid": true
+                },
+                {
+                    "input": { "contact": { "foo": "bar" } },
+                    "expectValid": true
+                }
+            ]
         },
         {
-          "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
-          "expectedRuleErrors" : ["openapi-tags-alphabetical"]
+            "object": "server",
+            "tests": [
+                {
+                    "input": { "url": "http://foo.com/" },
+                    "expectedRuleErrors" : ["server-trailing-slash"]
+                },
+                {
+                    "input": { "url": "http://foo.com" },
+                    "expectValid": true
+                }
+            ]
         },
         {
-          "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
-          "skip": [ "openapi-tags-alphabetical" ],
-          "expectValid": true
+            "object": "reference",
+            "tests": [
+                {
+                    "input": { "$ref": "./foo.yml" },
+                    "expectValid": true
+                },
+                {
+                    "input": { "$ref": "./foo.yml", "something": "else" },
+                    "expectedRuleErrors": ["reference-no-other-properties"]
+                }
+            ]
         },
         {
-          "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },
-          "expectValid": true
+            "object": "operation",
+            "tests": [
+                {
+                    "input": {},
+                    "expectedRuleErrors": [
+                        "operation-operationId",
+                        "operation-summary-or-description",
+                        "operation-tags"
+                    ]
+                },
+                {
+                    "input": { "summary": "thing", "operationId": "thing" },
+                    "expectedRuleErrors": ["operation-tags"]
+                },
+                {
+                    "input": {
+                        "summary": "thing",
+                        "operationId": "thing",
+                        "tags": [{ "name": "thing" }]
+                    },
+                    "expectValid": true
+                }
+            ]
         }
-      ]
-    },
-    {
-      "object": "info",
-      "tests": [
-        {
-          "input": {},
-          "expectedRuleErrors" : ["info-contact"]
-        },
-        {
-          "input": { "contact": {} },
-          "expectedRuleErrors" : ["info-contact"]
-        },
-        {
-          "input": {},
-          "skip": [ "info-contact" ],
-          "expectValid": true
-        },
-        {
-          "input": { "contact": { "foo": "bar" } },
-          "expectValid": true
-        }
-      ]
-    },
-    {
-      "object": "reference",
-      "tests": [
-        {
-          "input": {
-              "$ref": "./foo.yml"
-          },
-          "expectValid": true
-      },
-        {
-          "input": {
-              "$ref": "./foo.yml",
-              "something": "else"
-          },
-          "expectedRuleErrors": ["reference-no-other-properties"]
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,49 +1,10 @@
 'use strict';
 
-const path = require('path');
-const yaml = require('js-yaml');
 const server = require('../lib/server.js');
 
 describe('loadHTML()', () => {
     it('is a string', () => {
         const html = server.loadHTML();
         should(html).be.String();
-    });
-});
-
-
-describe('loadSpec()', () => {
-    const samplesDir = path.join(__dirname, './samples/');
-
-    it('loads test/samples/openapi.json', () => {
-        const spec = server.loadSpec(samplesDir + 'openapi.json');
-        should(yaml.load(spec)).have.key('openapi');
-    });
-
-    it('loads test/samples/openapi.yaml', () => {
-        const spec = server.loadSpec(samplesDir + 'openapi.yaml');
-        should(yaml.load(spec)).have.key('openapi');
-    });
-
-    it('throws OpenError for test/samples/nope.yaml', () => {
-        let thrownError;
-        try {
-            server.loadSpec(samplesDir + 'nope.yaml');
-        }
-        catch (error) {
-            thrownError = error;
-        }
-        should(thrownError.name).equal('OpenError');
-    });
-
-    it('throws OpenError for test/samples/not-openapi.csv', () => {
-        let thrownError;
-        try {
-            server.loadSpec(samplesDir + 'not-openapi.txt');
-        }
-        catch (error) {
-            thrownError = error;
-        }
-        should(thrownError.name).equal('ReadError');
     });
 });


### PR DESCRIPTION
When running serve on a $ref-filled schema it fails to load the target. Instead of shows the same index.html so we dont even get a 404, just a invalid response error.

It turns out that lint was also not resolving correctly, so expect to start seeing more linting errors after updating.

For that reason I'm thinking this will be v0.5.0 Don't wanna break things for people on a minor.

**Todo**

- [ ] Need to add some tests