### PR TITLE
Allow $refs to link Objects

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -414,24 +414,31 @@ function checkServers(servers, options) {
     }
 }
 
-function checkLink(link, options) {
+function checkLink(link, openapi, options) {
+    if (link.$ref) {
+        let ref = link.$ref;
+        should(link.$ref).be.type('string');
+        if (options.lint) options.linter('reference',link,'$ref',options);
+        link = common.resolveInternal(openapi, ref);
+        should(link).not.be.exactly(false, 'Cannot resolve reference: ' + ref);
+    }
     link.should.be.type('object');
-    if (typeof link.operationRef !== 'undefined') {
+    if (typeof link.operationRef === 'undefined') {
+        link.should.have.property('operationId');
+    }
+    else {
         link.operationRef.should.be.type('string');
         link.should.not.have.property('operationId');
     }
-    else {
-        link.should.have.property('operationId');
+    if (typeof link.operationId === 'undefined') {
+        link.should.have.property('operationRef');
     }
-    if (typeof link.operationId !== 'undefined') {
+    else {
         link.operationId.should.be.type('string');
         link.should.not.have.property('operationRef');
         // validate operationId exists (external refs?)
     }
-    else {
-        link.should.have.property('operationRef');
-    }
-    if (typeof link.parameters != 'undefined') {
+    if (typeof link.parameters !== 'undefined') {
         link.parameters.should.be.type('object');
         link.parameters.should.not.be.an.Array();
     }
@@ -518,7 +525,7 @@ function checkResponse(response, contextServers, openapi, options) {
         contextAppend(options, 'links');
         for (let l in response.links) {
             contextAppend(options, l);
-            checkLink(response.links[l], options);
+            checkLink(response.links[l], openapi, options);
             options.context.pop();
         }
         options.context.pop();
@@ -1158,7 +1165,7 @@ function validateSync(openapi, options, callback) {
                 options.linter('reference',link,options);
             }
             else {
-                checkLink(link, options);
+                checkLink(link, openapi, options);
             }
             options.context.pop();
         }


### PR DESCRIPTION
* Addresses #21 
* Backports the fix from `swagger2openapi`
* Also include `if !/else` reworks to quiet eslint

Have PR'd this rather than applying directly, so a) it can get an approval first, b) we might want more tests and c) because I'm seeing four test failures (unchanged before and after this patch).

```
  19 passing (83ms)
  4 failing

  1) loadSpec()
       loads yaml specs:
     OpenError: ENOENT: no such file or directory, open '/home/mike/nodejs/speccy/test/samples/openapi.yaml'
      at readSpecFile.then.err (lib/loader.js:70:27)
      at <anonymous>

  2) loadSpec()
       does not resolve references by default:
     OpenError: ENOENT: no such file or directory, open '/home/mike/nodejs/speccy/test/samples/refs/openapi.yaml'
      at readSpecFile.then.err (lib/loader.js:70:27)
      at <anonymous>

  3) loadSpec()
       resolves refs when passed { resolve: true }:
     OpenError: ENOENT: no such file or directory, open '/home/mike/nodejs/speccy/test/samples/refs/openapi.yaml'
      at readSpecFile.then.err (lib/loader.js:70:27)
      at <anonymous>

  4) loadSpec()
       throws ReadError for invalid YAML/JSON:

      AssertionError: expected 'OpenError' to be 'ReadError'
      + expected - actual

      -OpenError
      +ReadError
      
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value (node_modules/should/cjs/should.js:356:19)
      at Context.it (test/loader.test.js:49:34)
      at <anonymous>
```