### PR TITLE
Increased Coverage for everything other than Resolver

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -7,6 +7,10 @@ const should = require('should');
 
 let loadedRules;
 
+function regexFromString(regex) {
+    return new RegExp(regex.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&"));
+}
+
 // TODO Eventually support more than just core files
 function deepMergeRules(ruleNickname, skipRules, rules = []) {
   const ruleFile = path.join(__dirname, '../rules/' + ruleNickname + '.json');
@@ -162,18 +166,17 @@ function lint(objectName, object, options = {}) {
             if (rule.notContain) {
                 const { value, properties } = rule.notContain;
                 for (const property of properties) {
-                    if (object[property] && (typeof object[property] === 'string') &&
-                        (object[property].indexOf(value) >= 0)) {
-                            ensure(rule, () => {
-                                should.fail(true,false,rule.description);
-                            });
+                    if (object[property]) {
+                        ensure(rule, () => {
+                            object[property].should.be.a.String().and.not.match(regexFromString(value), rule.description);
+                        });
                     }
                 }
             }
             if (rule.notEndWith) {
                 const { value, property } = rule.notEndWith;
                 ensure(rule, () => {
-                    should(object[property]).not.endWith(value)
+                    should(object[property]).not.endWith(value);
                 });
             }
             if (rule.maxLength) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,15 +5,9 @@ const fs = require('fs');
 const path = require('path');
 
 function loadHTML(file) {
-    try {
-        const templateFile = path.resolve(__dirname, '../templates/index.html');
-        const template = fs.readFileSync(templateFile, 'utf8');
-        return ejs.render(template, { spec: file });
-    }
-    catch (e) {
-        console.error('failed to load html file: ' + e.message);
-        process.exit(1);
-    }
+    const templateFile = path.resolve(__dirname, '../templates/index.html');
+    const template = fs.readFileSync(templateFile, 'utf8');
+    return ejs.render(template, { spec: file });
 }
 
 module.exports = { loadHTML };

--- a/serve.js
+++ b/serve.js
@@ -20,7 +20,7 @@ const htmlOrError = specFile => {
 
 const launchServer = (app, port, specFile) => {
     app.listen(port, () => {
-        console.log(`API Reference Doc server running on http://localhost:${port}!`);
+        console.log(`API docs server running on http://localhost:${port}!`);
     })
     .on('error', e => {
         console.error('Failed to start server: ' + e.message);
@@ -28,17 +28,16 @@ const launchServer = (app, port, specFile) => {
     });
 }
 
-const launchWatchServerOrError = (app, port, specFile) => {
+const launchWatchServer = (app, port, specFile) => {
     app.listen(port + 1, function () {
         const bs = browserSync.create();
         bs.init({
             files: [specFile],
             proxy: `http://localhost:${port+1}`,
             port,
-            logLevel: 'silent',
             open: false
         }, () => {
-            console.log(`API Reference Doc server running on http://localhost:${port}!`);
+            console.log(`API docs live server running on http://localhost:${port}!`);
         });
     })
     .on('error', function(e) {

--- a/serve.js
+++ b/serve.js
@@ -8,14 +8,53 @@ const path = require('path');
 const server = require('./lib/server.js');
 const loader = require('./lib/loader.js');
 
-const command = async (file, cmd) => {
+const htmlOrError = specFile => {
+    try {
+        return server.loadHTML(specFile);
+    }
+    catch (e) {
+        console.error('Failed to load HTML file: ' + e.message);
+        process.exit(1);
+    }
+}
+
+const launchServer = (app, port, specFile) => {
+    app.listen(port, () => {
+        console.log(`API Reference Doc server running on http://localhost:${port}!`);
+    })
+    .on('error', e => {
+        console.error('Failed to start server: ' + e.message);
+        process.exit(1);
+    });
+}
+
+const launchWatchServerOrError = (app, port, specFile) => {
+    app.listen(port + 1, function () {
+        const bs = browserSync.create();
+        bs.init({
+            files: [specFile],
+            proxy: `http://localhost:${port+1}`,
+            port,
+            logLevel: 'silent',
+            open: false
+        }, () => {
+            console.log(`API Reference Doc server running on http://localhost:${port}!`);
+        });
+    })
+    .on('error', function(e) {
+        console.error('Failed to start server: ' + e.message);
+        process.exit(1);
+    });
+}
+
+const command = async (specFile, cmd) => {
     const app = express();
     const port = cmd.port;
-    const verbose = cmd.quiet ? 1 : cmd.verbose
-
+    const verbose = cmd.quiet ? 1 : cmd.verbose;
     const bundleDir = path.dirname(require.resolve('redoc'));
-    const html = server.loadHTML(file);
-    const spec = await loader.readOrError(file, {
+
+    const html = htmlOrError(specFile);
+    const spec = await loader.readOrError(specFile, {
         resolve: true,
         verbose
     });
@@ -28,33 +67,7 @@ const command = async (file, cmd) => {
         res.send(html);
     });
 
-    if (cmd.watch) {
-        app.listen(port + 1, function () {
-            const bs = browserSync.create();
-            bs.init({
-                files: [file],
-                proxy: `http://localhost:${port+1}`,
-                port,
-                logLevel: 'silent',
-                open: false
-            }, function() {
-                console.log(`API Reference Doc server running on http://localhost:${port}!`);
-            });
-        })
-        .on('error', function(e) {
-            console.error('failed to start server: ' + e.message);
-            process.exit(1);
-        });
-    }
-    else {
-        app.listen(port, function () {
-            console.log(`API Reference Doc server running on http://localhost:${port}!`);
-        })
-        .on('error', function(e) {
-            console.error('failed to start server: ' + e.message);
-            process.exit(1);
-        });
-    }
+    cmd.watch ? launchWatchServer(app, port, specFile) : launchServer(app, port, specFile);
 }
 
 module.exports = { command };

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -7,24 +7,64 @@
             "object": "openapi",
             "tests": [
                 {
-                    "input": { "openapi": 3 },
-                    "expectedRuleErrors" : ["openapi-tags"]
+                    "input": {
+                        "openapi": 3
+                    },
+                    "expectedRuleErrors": [
+                        "openapi-tags"
+                    ]
                 },
                 {
-                    "input": { "openapi": 3, "tags": [] },
-                    "expectedRuleErrors" : ["openapi-tags"]
+                    "input": {
+                        "openapi": 3,
+                        "tags": []
+                    },
+                    "expectedRuleErrors": [
+                        "openapi-tags"
+                    ]
                 },
                 {
-                    "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
-                    "expectedRuleErrors" : ["openapi-tags-alphabetical"]
+                    "input": {
+                        "openapi": 3,
+                        "tags": [
+                            {
+                                "name": "foo"
+                            },
+                            {
+                                "name": "bar"
+                            }
+                        ]
+                    },
+                    "expectedRuleErrors": [
+                        "openapi-tags-alphabetical"
+                    ]
                 },
                 {
-                    "input": { "openapi": 3, "tags": [ {"name": "foo"}, {"name": "bar"} ]},
-                    "skip": [ "openapi-tags-alphabetical" ],
+                    "input": {
+                        "openapi": 3,
+                        "tags": [
+                            {
+                                "name": "foo"
+                            },
+                            {
+                                "name": "bar"
+                            }
+                        ]
+                    },
+                    "skip": [
+                        "openapi-tags-alphabetical"
+                    ],
                     "expectValid": true
                 },
                 {
-                    "input": { "openapi": 3, "tags": [ {"name": "foo"} ] },
+                    "input": {
+                        "openapi": 3,
+                        "tags": [
+                            {
+                                "name": "foo"
+                            }
+                        ]
+                    },
                     "expectValid": true
                 }
             ]
@@ -34,19 +74,31 @@
             "tests": [
                 {
                     "input": {},
-                    "expectedRuleErrors" : ["info-contact"]
+                    "expectedRuleErrors": [
+                        "info-contact"
+                    ]
                 },
                 {
-                    "input": { "contact": {} },
-                    "expectedRuleErrors" : ["info-contact"]
+                    "input": {
+                        "contact": {}
+                    },
+                    "expectedRuleErrors": [
+                        "info-contact"
+                    ]
                 },
                 {
                     "input": {},
-                    "skip": [ "info-contact" ],
+                    "skip": [
+                        "info-contact"
+                    ],
                     "expectValid": true
                 },
                 {
-                    "input": { "contact": { "foo": "bar" } },
+                    "input": {
+                        "contact": {
+                            "foo": "bar"
+                        }
+                    },
                     "expectValid": true
                 }
             ]
@@ -55,11 +107,17 @@
             "object": "server",
             "tests": [
                 {
-                    "input": { "url": "http://foo.com/" },
-                    "expectedRuleErrors" : ["server-trailing-slash"]
+                    "input": {
+                        "url": "http://foo.com/"
+                    },
+                    "expectedRuleErrors": [
+                        "server-trailing-slash"
+                    ]
                 },
                 {
-                    "input": { "url": "http://foo.com" },
+                    "input": {
+                        "url": "http://foo.com"
+                    },
                     "expectValid": true
                 }
             ]
@@ -68,12 +126,19 @@
             "object": "reference",
             "tests": [
                 {
-                    "input": { "$ref": "./foo.yml" },
+                    "input": {
+                        "$ref": "./foo.yml"
+                    },
                     "expectValid": true
                 },
                 {
-                    "input": { "$ref": "./foo.yml", "something": "else" },
-                    "expectedRuleErrors": ["reference-no-other-properties"]
+                    "input": {
+                        "$ref": "./foo.yml",
+                        "something": "else"
+                    },
+                    "expectedRuleErrors": [
+                        "reference-no-other-properties"
+                    ]
                 }
             ]
         },
@@ -89,14 +154,23 @@
                     ]
                 },
                 {
-                    "input": { "summary": "thing", "operationId": "thing" },
-                    "expectedRuleErrors": ["operation-tags"]
+                    "input": {
+                        "summary": "thing",
+                        "operationId": "thing"
+                    },
+                    "expectedRuleErrors": [
+                        "operation-tags"
+                    ]
                 },
                 {
                     "input": {
                         "summary": "thing",
                         "operationId": "thing",
-                        "tags": [{ "name": "thing" }]
+                        "tags": [
+                            {
+                                "name": "thing"
+                            }
+                        ]
                     },
                     "expectValid": true
                 }

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -175,6 +175,35 @@
                     "expectValid": true
                 }
             ]
+        },
+        {
+            "object": "example",
+            "tests": [
+                {
+                    "input": {
+                        "summary": "User Example"
+                    },
+                    "expectedRuleErrors": [
+                        "example-value-or-externalValue"
+                    ]
+                },
+                {
+                    "input": {
+                        "summary": "User Example",
+                        "value": {
+                            "foo": "bar"
+                        }
+                    },
+                    "expectValid": true
+                },
+                {
+                    "input": {
+                        "summary": "User Example",
+                        "externalValue": "http://foo.bar/examples/user-example.json"
+                    },
+                    "expectValid": true
+                }
+            ]
         }
     ]
 }

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -156,10 +156,12 @@
                 {
                     "input": {
                         "summary": "thing",
-                        "operationId": "thing"
+                        "operationId": "thing",
+                        "description": "foo <script> bla"
                     },
                     "expectedRuleErrors": [
-                        "operation-tags"
+                        "operation-tags",
+                        "no-script-tags-in-markdown"
                     ]
                 },
                 {
@@ -171,35 +173,6 @@
                                 "name": "thing"
                             }
                         ]
-                    },
-                    "expectValid": true
-                }
-            ]
-        },
-        {
-            "object": "example",
-            "tests": [
-                {
-                    "input": {
-                        "summary": "User Example"
-                    },
-                    "expectedRuleErrors": [
-                        "example-value-or-externalValue"
-                    ]
-                },
-                {
-                    "input": {
-                        "summary": "User Example",
-                        "value": {
-                            "foo": "bar"
-                        }
-                    },
-                    "expectValid": true
-                },
-                {
-                    "input": {
-                        "summary": "User Example",
-                        "externalValue": "http://foo.bar/examples/user-example.json"
                     },
                     "expectValid": true
                 }

--- a/test/profiles/default.json
+++ b/test/profiles/default.json
@@ -204,6 +204,35 @@
                     "expectValid": true
                 }
             ]
+        },
+        {
+            "object": "example",
+            "tests": [
+                {
+                    "input": {
+                        "summary": "User Example"
+                    },
+                    "expectedRuleErrors": [
+                        "example-value-or-externalValue"
+                    ]
+                },
+                {
+                    "input": {
+                        "summary": "User Example",
+                        "value": {
+                            "foo": "bar"
+                        }
+                    },
+                    "expectValid": true
+                },
+                {
+                    "input": {
+                        "summary": "User Example",
+                        "externalValue": "http://foo.bar/examples/user-example.json"
+                    },
+                    "expectValid": true
+                }
+            ]
         }
     ]
 }

--- a/test/profiles/strict.json
+++ b/test/profiles/strict.json
@@ -1,0 +1,37 @@
+{
+    "rules": [
+        "strict"
+    ],
+    "fixtures": [
+        {
+            "object": "contact",
+            "tests": [
+                {
+                    "input": {},
+                    "expectedRuleErrors": [
+                        "contact-properties",
+                        "contact-properties",
+                        "contact-properties"
+                    ]
+                },
+                {
+                    "input": {
+                        "name": "Support",
+                        "url": "http://example.org/contact"
+                    },
+                    "expectedRuleErrors": [
+                        "contact-properties"
+                    ]
+                },
+                {
+                    "input": {
+                        "name": "Support",
+                        "url": "http://example.org/contact",
+                        "email": "support@example.org"
+                    },
+                    "expectValid": true
+                }
+            ]
+        }
+    ]
+}

--- a/test/samples/no-contact.yaml
+++ b/test/samples/no-contact.yaml
@@ -1,0 +1,8 @@
+---
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger 2.0 Without Scheme
+  contact:
+    name: Phil
+paths: {}


### PR DESCRIPTION
Improve coverage for server by making the serve command handle exits, started testing strict profile to cover deepMergeRules, and added tests for a few more rules.

Nobody is going to get excited over a 2.8% increase, but it's actually bigger than that. `lib/resolver.js` is really poorly tested, but when we dump that for @MikeRalphson's "openapi-tools" resolver, the coverage will look much nicer.