### PR TITLE
Fix args parsing

### DIFF
--- a/speccy.js
+++ b/speccy.js
@@ -40,10 +40,11 @@ program
     .option('-p, --port [value]', 'port on which the server will listen', 5000)
     .option('-q, --quiet', 'reduce verbosity')
     .option('-v, --verbose', 'increase verbosity', 2)
-    .option('-w, --watch', 'reloding browser on spec file changes')
+    .option('-w, --watch', 'reloading browser on spec file changes')
     .action(serve.command);
 
-program.parse(process.argv);
+program.parse(process.argv,function(){
+    // Show help if nothing else is going on
+    if (!program.args.length) program.help();
+});
 
-// Show help if nothing else is going on
-if (!program.args.length) program.help();


### PR DESCRIPTION
This fixes the behaviour with `commander`s options parsing noted in #23 

The problem was that `program.parse` is an async method and the test for no arguments was happening synchronously.