### PR TITLE
Warn on malformed json/yaml includes, refs #36

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -172,7 +172,8 @@ function resolveExternal(root, pointer, options, callback) {
                     data = resolveAllInternal(data, context, pointer, fragment, target, options);
                 }
                 catch (ex) {
-                    if (options.verbose) console.warn(ex);
+                    if (!options.verbose) console.warn('GET', target, fragment);
+                    console.warn(ex);
                 }
                 callback(data, target, options);
                 return data;
@@ -201,7 +202,8 @@ function resolveExternal(root, pointer, options, callback) {
                     data = resolveAllInternal(data, context, pointer, fragment, target, options);
                 }
                 catch (ex) {
-                    if (options.verbose) console.warn(ex);
+                    if (!options.verbose) console.warn('GET', target, fragment);
+                    console.warn(ex);
                 }
                 callback(data, target, options);
                 return data;


### PR DESCRIPTION
We now always show the json/yaml parsing exceptions for `$ref`d documents.

To aid debugging, if `--verbose` is not set, we output the source of the document before the exception.