### PR TITLE
Taming error messages

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -12,7 +12,9 @@ const ensureRule = (context, rule, shouldAssertion, results) => {
     }
     catch (error) {
         // rethrow when not a lint error
-        if (!error.name || error.name !== "AssertionError") throw error;
+        if (!error.name || error.name !== "AssertionError") {
+            throw error;
+        }
 
         const pointer = (context && context.length > 0 ? context[context.length-1] : null);
         const result = { pointer, rule, error };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,7 +10,7 @@ const util = require('util');
 const yaml = require('js-yaml');
 const should = require('should');
 const co = require('co');
-var ajv = require('ajv')({
+const ajv = require('ajv')({
     allErrors: true,
     verbose: true,
     jsonPointers: true,
@@ -19,19 +19,13 @@ var ajv = require('ajv')({
 });
 //meta: false, // optional, to prevent adding draft-06 meta-schema
 
-var ajvFormats = require('ajv/lib/compile/formats.js');
-ajv.addFormat('uriref', ajvFormats.full['uri-reference']);
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-ajv._refs['http://json-schema.org/schema'] = 'http://json-schema.org/draft-04/schema'; // optional, using unversioned URI is out of spec
-var metaSchema = require('ajv/lib/refs/json-schema-v5.json');
-ajv.addMetaSchema(metaSchema);
-ajv._opts.defaultMeta = metaSchema.id;
-
 const common = require('./common.js');
 const jptr = require('reftools/lib/jptr.js');
 const walkSchema = require('./walkSchema.js').walkSchema;
 const wsGetDefaultState = require('./walkSchema.js').getDefaultState;
 const linter = require('./linter.js');
+
+setupAjv(ajv);
 
 const jsonSchema = require('../schemas/json_v5.json');
 const validateMetaSchema = ajv.compile(jsonSchema);
@@ -40,6 +34,23 @@ let validateOpenAPI3 = ajv.compile(openapi3Schema);
 
 const dummySchema = { anyOf: {} };
 const emptySchema = {};
+
+class JSONSchemaError extends Error {
+    constructor(message, params) {
+        super(message);
+        this.errors = params.errors;
+    }
+}
+
+function setupAjv(ajv) {
+    const ajvFormats = require('ajv/lib/compile/formats.js');
+    ajv.addFormat('uriref', ajvFormats.full['uri-reference']);
+    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+    ajv._refs['http://json-schema.org/schema'] = 'http://json-schema.org/draft-04/schema'; // optional, using unversioned URI is out of spec
+    const metaSchema = require('ajv/lib/refs/json-schema-v5.json');
+    ajv.addMetaSchema(metaSchema);
+    ajv._opts.defaultMeta = metaSchema.id;
+}
 
 function contextAppend(options, s) {
     options.context.push((options.context[options.context.length - 1] + '/' + s).split('//').join('/'));
@@ -367,7 +378,9 @@ function checkContent(content, contextServers, openapi, options) {
             }
             options.context.pop();
         }
-        if (typeof contentType.schema !== 'undefined') checkSchema(contentType.schema, emptySchema, 'schema', openapi, options);
+        if (typeof contentType.schema !== 'undefined') {
+            checkSchema(contentType.schema, emptySchema, 'schema', openapi, options);
+        }
         options.context.pop();
     }
     options.context.pop();
@@ -1198,9 +1211,9 @@ function validateSync(openapi, options, callback) {
     }
 
     validateOpenAPI3(openapi);
-    var errors = validateOpenAPI3.errors;
+    const errors = validateOpenAPI3.errors;
     if (errors && errors.length) {
-        throw (new Error('Failed OpenAPI3 schema validation: ' + JSON.stringify(errors, null, 2)));
+        throw new JSONSchemaError('Failed OpenAPI v3 schema validation', { errors });
     }
 
     options.valid = !options.expectFailure;
@@ -1255,4 +1268,7 @@ function validate(openapi, options, callback) {
     });
 }
 
-module.exports = { validate }
+module.exports = {
+    validate,
+    JSONSchemaError
+}

--- a/lint.js
+++ b/lint.js
@@ -19,18 +19,34 @@ const colors = process.env.NODE_DISABLE_COLORS ? {} : {
 
 const formatSchemaError = (err, context) => {
   const pointer = context.pop();
-  const message = err.message;
-  let output;
 
-  output = `
+  let output = `
 ${colors.yellow + pointer}
-${colors.reset + message}
 `;
 
-  if (err.stack && err.name !== 'AssertionError') {
-      output += colors.red + err.stack + colors.reset;
+  if (err.name === 'AssertionError') {
+      output += colors.reset + err.message;
+  }
+  else if (err instanceof validator.JSONSchemaError) {
+      output += colors.reset + readableErrorMessages(err).join('\n');
+  }
+  else {
+      output += colors.red + err.stack;
   }
   return output;
+}
+
+function readableErrorMessages(err) {
+    return err.errors.map(function(error) {
+        const { dataPath, params } = error;
+        if (params.missingProperty) {
+            return `${dataPath} is missing property: ${params.missingProperty}`;
+        }
+        if (params.additionalProperty) {
+            return `${dataPath} has an unexpected additional property: ${params.additionalProperty}`;
+        }
+        return `unhandled invalid error: ${error}`;
+    });
 }
 
 const formatLintResults = lintResults => {

--- a/lint.js
+++ b/lint.js
@@ -19,7 +19,6 @@ const colors = process.env.NODE_DISABLE_COLORS ? {} : {
 
 const formatSchemaError = (err, context) => {
   const pointer = context.pop();
-
   let output = `
 ${colors.yellow + pointer}
 `;
@@ -28,7 +27,7 @@ ${colors.yellow + pointer}
       output += colors.reset + err.message;
   }
   else if (err instanceof validator.JSONSchemaError) {
-      output += colors.reset + readableErrorMessages(err).join('\n');
+      output += colors.reset + readableJsonSchemaMessages(err).join('\n');
   }
   else {
       output += colors.red + err.stack;
@@ -36,8 +35,8 @@ ${colors.yellow + pointer}
   return output;
 }
 
-function readableErrorMessages(err) {
-    return err.errors.map(function(error) {
+function readableJsonSchemaMessages(err) {
+    return err.errors.map(error => {
         const { dataPath, params } = error;
         if (params.missingProperty) {
             return `${dataPath} is missing property: ${params.missingProperty}`;
@@ -49,6 +48,17 @@ function readableErrorMessages(err) {
     });
 }
 
+const truncateLongMessages = message => {
+    let lines = message.split('\n');
+    if (lines.length > 6) {
+        lines = lines.slice(0, 5).concat(
+            ['  ... snip ...'],
+            lines.slice(-1)
+        );
+    }
+    return lines.join('\n');
+}
+
 const formatLintResults = lintResults => {
     let output = '';
     lintResults.forEach(result => {
@@ -56,7 +66,7 @@ const formatLintResults = lintResults => {
 
         output += `
 ${colors.yellow + pointer} ${colors.cyan} R: ${rule.name} ${colors.white} D: ${rule.description}
-${colors.reset + error.message}
+${colors.reset + truncateLongMessages(error.message)}
 `;
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "speccy",
-    "version": "0.5.3",
+    "version": "0.5.4-3",
     "description": "Your friendly OpenAPI v3.0 #WellActually CLI assistant.",
     "bin": {
         "speccy": "./speccy.js"

--- a/test/samples/no-contact.yaml
+++ b/test/samples/no-contact.yaml
@@ -3,6 +3,16 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: Swagger 2.0 Without Scheme
-  contact:
-    name: Phil
 paths: {}
+components:
+    schemas:
+        foo:
+            type: object
+        bar:
+            type: object
+        baz:
+            type: object
+        ban:
+            type: object
+        basdf:
+            type: object


### PR DESCRIPTION
Truncate any assertion-based linter errors
```
expected Object {
  openapi: '3.0.0',
   info: Object { version: '1.0.0', title: 'Swagger 2.0 Without Scheme'
  },
  paths: Object {},
  components: Object {
  ... snip ...
} to have property tags
```

This will also show a considerably more concise JSON Schema error in situations where speccy knows
whats up.
```
Specification schema is invalid.
  /components has an unexpected additional property: properties
```