### PR TITLE
Optionally support treating $ref like JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ## Removed
 - Removed switch --watch as it didn't actually work, and was flagging "security issues" on npm
-
+## Added
+- New switch `--json-schema / -j` will tell speccy to resolve $refs as JSON Schema, converting them to OpenAPI on the fly
 
 ## [0.5.4] - 2018-04-04
 ### Changed

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch');
 const yaml = require('js-yaml');
 const jptr = require('reftools/lib/jptr.js').jptr;
 const common = require('./common.js');
+const fromJsonSchema = require('json-schema-to-openapi-schema');
 
 const red = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[31m';
 const green = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[32m';
@@ -28,8 +29,7 @@ function readFileAsync(filename, encoding) {
 }
 
 function resolveAllInternal(obj, context, src, parentPath, base, options) {
-
-    let attachPoint = options.externalRefs[src+parentPath].paths[0];
+    const attachPoint = options.externalRefs[src+parentPath].paths[0];
 
     let baseUrl = url.parse(base);
     let seen = {}; // seen is indexed by the $ref value and contains path replacements
@@ -104,8 +104,8 @@ function resolveAllInternal(obj, context, src, parentPath, base, options) {
 }
 
 function resolveExternal(root, pointer, options, callback) {
-    var u = url.parse(options.source);
-    var base = options.source.split('\\').join('/').split('/');
+    const u = url.parse(options.source);
+    let base = options.source.split('\\').join('/').split('/');
     let doc = base.pop(); // drop the actual filename
     if (!doc) base.pop(); // in case it ended with a /
     let fragment = '';
@@ -144,24 +144,32 @@ function resolveExternal(root, pointer, options, callback) {
 
     if (options.handlers && options.handlers[effectiveProtocol]) {
         return options.handlers[effectiveProtocol](base, pointer, fragment, options)
-            .then(function (data) {
+            .then(data => {
+                if (options.jsonSchema) return fromJsonSchema(data);
+                return data;
+            })
+            .then(data => {
                 callback(data, target, options);
                 return data;
             })
-            .catch(function(ex){
+            .catch(ex => {
                 if (options.verbose) console.warn(ex);
             });
     }
     else if (u.protocol && u.protocol.startsWith('http')) {
         return fetch(target, { agent: options.agent })
-            .then(function (res) {
+            .then(res => {
                 if (res.status !== 200) throw new Error(`Received status code ${res.status}`);
                 return res.text();
             })
-            .then(function (data) {
+            .then(data => {
+                data = yaml.safeLoad(data, { json: true });
+                if (options.jsonSchema) data = fromJsonSchema(data);
+                return data;
+            })
+            .then(data => {
                 try {
-                    let context = yaml.safeLoad(data, { json: true });
-                    data = context;
+                    const context = data;
                     options.cache[target] = common.clone(data);
 
                     /* resolutionSource:B, from the network, data is fresh, but we clone it into the cache */
@@ -186,10 +194,15 @@ function resolveExternal(root, pointer, options, callback) {
     }
     else {
         return readFileAsync(target, options.encoding || 'utf8')
-            .then(function (data) {
+            .then(data => {
+                data = yaml.safeLoad(data, { json: true });
+                if (options.jsonSchema) data = fromJsonSchema(data);
+                return data;
+            })
+            .then(data => {
                 try {
-                    const context = yaml.safeLoad(data, { json: true });
-                    data = context;
+                    // Make a copy of the context, data might change
+                    const context = data;
 
                     /*
                         resolutionSource:C from a file, data is fresh but we clone it into the cache
@@ -260,8 +273,8 @@ function findExternalRefs(options) {
     return new Promise(function (res) {
 
         scanExternalRefs(options)
-            .then(function (refs) {
-                for (let ref in refs) {
+            .then(refs => {
+                for (const ref in refs) {
 
                     // we must check the ref's source matches ours. Nested external $refs have been url-resolved
                     // TODO: forUs might be unnecessary, leading to refs[ref].sources being unnecessary now?
@@ -316,10 +329,10 @@ base: options.resolver.base
                                             refs[ref].resolvedAt = ptr;
                                             if (options.verbose>1) console.log('Creating initial clone of data at', ptr);
                                         }
-                                        else {
-                                            if (options.verbose>1) console.log('Avoiding circular reference');
+                                        else if (options.verbose>1) {
+                                            console.log('Avoiding circular reference');
                                         }
-                                        let cdata = common.clone(data);
+                                        const cdata = common.clone(data);
                                         jptr(options.openapi, ptr, cdata); // resolutionCase:F (cloned:yes)
                                     }
                                 }
@@ -332,7 +345,7 @@ base: options.resolver.base
                     }
                 }
             })
-            .catch(function(ex){
+            .catch(ex => {
                 if (options.verbose) console.warn(ex);
             });
 
@@ -349,7 +362,7 @@ const serial = funcs =>
 const loopReferences = (options, res, rej) => {
     options.resolver.actions.push([]);
     findExternalRefs(options)
-        .then(function (data) {
+        .then(data => {
             serial(data.actions)
                 .then(function () {
                     if (options.resolver.depth>=options.resolver.actions.length) {
@@ -369,11 +382,11 @@ const loopReferences = (options, res, rej) => {
                         }
                     }
                 })
-                .catch(function (ex) {
+                .catch(ex => {
                     if (options.verbose) console.warn(ex);
                 });
         })
-        .catch(function(ex){
+        .catch(ex => {
             if (options.verbose) console.warn(ex);
         });
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -2,12 +2,8 @@
 
 'use strict';
 
-const fs = require('fs');
 const url = require('url');
 const URL = url.URL;
-const util = require('util');
-
-const yaml = require('js-yaml');
 const should = require('should');
 const co = require('co');
 var ajv = require('ajv')({
@@ -35,8 +31,8 @@ const linter = require('./linter.js');
 
 const jsonSchema = require('../schemas/json_v5.json');
 const validateMetaSchema = ajv.compile(jsonSchema);
-let openapi3Schema = require('../schemas/openapi-3.0.json');
-let validateOpenAPI3 = ajv.compile(openapi3Schema);
+const openapi3Schema = require('../schemas/openapi-3.0.json');
+const validateOpenAPI3 = ajv.compile(openapi3Schema);
 
 const dummySchema = { anyOf: {} };
 const emptySchema = {};
@@ -46,8 +42,7 @@ function contextAppend(options, s) {
 }
 
 function validateUrl(s, contextServers, context, options) {
-    s.should.be.a.String();
-    s.should.not.be.Null();
+    s.should.be.a.String().and.not.be.Null();
     if (!options.laxurls) s.should.not.be.exactly('', 'Invalid empty URL ' + context);
     var base = options.origin || 'http://localhost/';
     if (contextServers && contextServers.length) {
@@ -822,11 +817,6 @@ function checkSecurity(security,openapi,options) {
 
 function validateSync(openapi, options, callback) {
     setupOptions(options,openapi);
-    if (options.jsonschema) {
-        let schemaStr = fs.readFileSync(options.jsonschema, 'utf8');
-        openapi3Schema = yaml.safeLoad(schemaStr, { json: true });
-        validateOpenAPI3 = ajv.compile(openapi3Schema);
-    }
 
     should(openapi).be.an.Object();
     openapi.should.not.have.key('swagger');

--- a/lint.js
+++ b/lint.js
@@ -49,7 +49,14 @@ ${colors.reset + error.message}
 
 const command = async (file, cmd) => {
     const verbose = cmd.quiet ? 1 : cmd.verbose;
-    const spec = await loader.readOrError(file, { verbose, resolve: true });
+
+    const options = {
+        jsonSchema: cmd.jsonSchema === true,
+        resolve: true,
+        verbose,
+    }
+
+    const spec = await loader.readOrError(file, options);
     const rules = loader.loadRules(cmd.rules, cmd.skip);
 
     if (verbose > 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,6 +3787,11 @@
         }
       }
     },
+    "json-schema-to-openapi-schema": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-openapi-schema/-/json-schema-to-openapi-schema-0.1.0.tgz",
+      "integrity": "sha512-17jJUTUit7AIT7DaD+mK+mjC1kktdbhibG9CXZs0/u4fDZnQx/0NTQp6Z9biRVItZXZwgXZrLUyfPKUOJeAIyQ=="
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "ejs": "^2.5.2",
         "express": "^4.14.0",
         "js-yaml": "^3.6.1",
+        "json-schema-to-openapi-schema": "^0.1.0",
         "node-fetch": "^1.7.3",
         "node-readfiles": "^0.2.0",
         "redoc": "next",

--- a/resolve.js
+++ b/resolve.js
@@ -16,22 +16,28 @@ const options = {
     status: 'undefined',
 };
 
-const main = (str, output) => {
-    options.openapi = yaml.safeLoad(str,{json:true});
+const main = (str, outputFile) => {
+    options.openapi = yaml.safeLoad(str, { json: true });
     resolver.resolve(options)
-        .then(function(){
-            fs.writeFileSync(output, yaml.safeDump(options.openapi,{lineWidth:-1}),'utf8');
-            console.log('Resolved to ' + output);
+        .then(() => {
+            const content = yaml.safeDump(options.openapi, { lineWidth: -1 });
+            if (outputFile) {
+                fs.writeFile(outputFile, content, 'utf8', () => {
+                    console.log('Resolved to ' + outputFile);
+                });
+            }
+            else {
+                console.log(content);
+            }
             process.exit(0);
         })
-        .catch(function(err){
-            console.warn(err);
-        });
+        .catch(err => console.warn(err));
 };
 
 const command = (file, cmd) => {
     options.origin = file;
     options.source = file;
+    options.jsonSchema = cmd.jsonSchema === true;
     options.verbose = cmd.quiet ? 1 : cmd.verbose;
 
     if (file && file.startsWith('http')) {

--- a/serve.js
+++ b/serve.js
@@ -36,6 +36,7 @@ const command = async (specFile, cmd) => {
 
     const html = htmlOrError(specFile);
     const spec = await loader.readOrError(specFile, {
+        jsonSchema: cmd.jsonSchema === true,
         resolve: true,
         verbose
     });

--- a/speccy.js
+++ b/speccy.js
@@ -24,13 +24,15 @@ program
     .option('-q, --quiet', 'reduce verbosity')
     .option('-r, --rules [ruleFile]', 'Provide multiple rules files', collect, [])
     .option('-s, --skip [ruleName]', 'Provide multiple rules to skip', collect, [])
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
     .option('-v, --verbose', 'increase verbosity', 2)
     .action(lint.command);
 
 program
     .command('resolve <file-or-url>')
-    .option('-o, --output <file>', 'file to output to', 'resolved.yaml')
+    .option('-o, --output <file>', 'file to output to')
     .option('-q, --quiet', 'reduce verbosity')
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
     .option('-v, --verbose', 'increase verbosity', 2)
     .action(resolve.command);
 
@@ -39,6 +41,7 @@ program
     .description('View specifications in beautiful human readable documentation')
     .option('-p, --port [value]', 'port on which the server will listen', 5000)
     .option('-q, --quiet', 'reduce verbosity')
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
     .option('-v, --verbose', 'increase verbosity', 2)
     // TODO .option('-w, --watch', 'reloading browser on spec file changes')
     .action(serve.command);
@@ -47,4 +50,3 @@ program.parse(process.argv,function(){
     // Show help if nothing else is going on
     if (!program.args.length) program.help();
 });
-

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -83,6 +83,26 @@ describe('loader.js', () => {
             should(spec.paths['/a'].post.description).equal('Some operation object');
         });
 
+        it('resolves JSON Schema $refs when passed { jsonSchema: true }', async () => {
+            const spec = await loader.loadSpec(samplesDir + 'json-schema/openapi.yaml', {
+                jsonSchema: true,
+                resolve: true
+            });
+
+            const properties = spec.paths['/a'].get.responses['200'].content['application/json'].schema.properties;
+            should(properties.foo).match({
+                "readOnly": true,
+                "type": "string",
+                "example": "123"
+            });
+            should(properties.bar).match({
+                "type": "string",
+                "format": "uuid",
+                "example": "12345",
+                "nullable": true
+            });
+        });
+
         it('throws OpenError for non-existant file', async () => {
             let thrownError;
             try {

--- a/test/samples/json-schema/a.json
+++ b/test/samples/json-schema/a.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "readOnly": true,
+            "type": "string",
+            "example": "123"
+        },
+        "bar": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "example": "12345"
+        },
+        "baz": {
+            "type": ["string", "null"],
+            "format": "date-time"
+        }
+    },
+    "required": [
+        "foo",
+        "bar"
+    ]
+}

--- a/test/samples/json-schema/openapi.yaml
+++ b/test/samples/json-schema/openapi.yaml
@@ -1,0 +1,16 @@
+---
+openapi: 3.0.0
+info:
+    version: 1.0.0
+    title: OpenAPI /w JSON Schema Example
+paths:
+    /a:
+        get:
+            summary: foo
+            responses:
+                200:
+                    description: 'OK'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: './a.json'

--- a/test/samples/refs/definitions/b.yml
+++ b/test/samples/refs/definitions/b.yml
@@ -1,0 +1,10 @@
+Reservation:
+  title: Reservation
+  type: object
+  properties:
+    id:
+      type: integer
+      example: 3576387
+    start:
+      type: string
+      example: '2017-12-04T13:00:00.000Z'


### PR DESCRIPTION
We use JSON Schema for contract testing, and want to reuse those JSON Schema models for OpenAPI documentation. Seeing as OpenAPI has imperfect (subset & superset) support for JSON Schema, we have to convert one to the other at runtime. 

For now it is using an optional switch, which is a little annoying to do every time, but when #14 is done that'll just go in the config file. 

**Example**

<img width="859" alt="screen shot 2018-04-06 at 11 48 21 am" src="https://user-images.githubusercontent.com/67381/38432964-2ff29bdc-3997-11e8-8238-2c9c5ee9a641.png">

