### PR TITLE
Daftly left require(browser-sync) in place 

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const browserSync = require('browser-sync');
 const express = require('express');
 const path = require('path');
 const server = require('./lib/server.js');


### PR DESCRIPTION
It still worked for the contributors who tested it because they still had browser-sync locally, despite being removed from the package.json. I dont like NPM much.