### PR TITLE
Add descriptions to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Options:
 
 Commands:
 
-  lint [options] <file-or-url>
-  resolve [options] <file-or-url>
-  serve [options] <file>
+  lint [options] <file-or-url>     ensure specs are not just valid OpenAPI, but lint against specified rules
+  resolve [options] <file-or-url>  pull in external $ref files to create one mega-file
+  serve [options] <file-or-url>    view specifications in beautiful human readable documentation
 ```
 
 ### Lint Command
@@ -38,13 +38,16 @@ The goal here is to sniff your files for potentially bad things. "Bad" is object
 ```
 Usage: lint [options] <file-or-url>
 
-Ensure your OpenAPI files are valid and up to scratch
+ensure specs are not just valid OpenAPI, but lint against specified rules
 
 Options:
 
-    -r, --rules [ruleFile]  use this multiple times to select multiple rules files
-    -s, --skip [ruleName]   use this multiple times to skip specific rules
-    -h, --help              output usage information
+  -q, --quiet             reduce verbosity
+  -r, --rules [ruleFile]  provide multiple rules files
+  -s, --skip [ruleName]   provide multiple rules to skip
+  -j, --json-schema       treat $ref like JSON Schema and convert to OpenAPI Schema Objects
+  -v, --verbose           increase verbosity
+  -h, --help              output usage information
 ```
 
 You'll see output such as:
@@ -72,18 +75,20 @@ Contributions of rules and rule actions for the linter are very much appreciated
 
 ### Serve Command
 
-Using [ReDoc] and the handy utility [redocup], speccy can offer a preview of your
-specifications, in human-readable format. In the future we'll have speccy outlining improvements right in here, but one thing at a time ey?
+Using [ReDoc], speccy can offer a preview of your specifications, in human-readable format.
+In the future we'll have speccy outlining improvements right in here, but one thing at a time.
 
 ```
-Usage: serve [options] spec-json-or-yaml-path
+Usage: serve [options] <file-or-url>
 
-View specifications in beautiful human readable documentation
+view specifications in beautiful human readable documentation
 
 Options:
 
   -p, --port [value]  port on which the server will listen (default: 5000)
-  -w, --watch         reloding browser on spec file changes
+  -q, --quiet         reduce verbosity
+  -j, --json-schema   treat $ref like JSON Schema and convert to OpenAPI Schema Objects
+  -v, --verbose       increase verbosity
   -h, --help          output usage information
 ```
 

--- a/speccy.js
+++ b/speccy.js
@@ -21,15 +21,17 @@ program
 
 program
     .command('lint <file-or-url>')
+    .description('ensure specs are not just valid OpenAPI, but lint against specified rules')
     .option('-q, --quiet', 'reduce verbosity')
-    .option('-r, --rules [ruleFile]', 'Provide multiple rules files', collect, [])
-    .option('-s, --skip [ruleName]', 'Provide multiple rules to skip', collect, [])
+    .option('-r, --rules [ruleFile]', 'provide multiple rules files', collect, [])
+    .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
     .option('-v, --verbose', 'increase verbosity', 2)
     .action(lint.command);
 
 program
     .command('resolve <file-or-url>')
+    .description('pull in external $ref files to create one mega-file')
     .option('-o, --output <file>', 'file to output to')
     .option('-q, --quiet', 'reduce verbosity')
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
@@ -38,7 +40,7 @@ program
 
 program
     .command('serve <file-or-url>')
-    .description('View specifications in beautiful human readable documentation')
+    .description('view specifications in beautiful human readable documentation')
     .option('-p, --port [value]', 'port on which the server will listen', 5000)
     .option('-q, --quiet', 'reduce verbosity')
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
@@ -46,7 +48,6 @@ program
     // TODO .option('-w, --watch', 'reloading browser on spec file changes')
     .action(serve.command);
 
-program.parse(process.argv,function(){
-    // Show help if nothing else is going on
-    if (!program.args.length) program.help();
-});
+program.parse(process.argv);
+
+if (!program.args.length) program.help();


### PR DESCRIPTION
Fixes #59

README was not kept up to date with some of the options and descriptions added recently, and some commands were missing descriptions.