### PR TITLE
Don't print "GET filename" when quiet

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -50,7 +50,7 @@ const fetchUrl = async (url) => {
 
 
 function readSpecFile(file, options) {
-    if (options.verbose) {
+    if (options.verbose > 1) {
         console.log('GET ' + file);
     }
     if (file && file.startsWith('http')) {


### PR DESCRIPTION
Actually not sure why `--quiet` wouldn't default to `verbose = 0` across the codebase, but fixing this at least to avoid outputting this line in quiet mode.

On a related note, it would be nice if quiet mode would print nothing if linting succeeded (i.e., not print "Specification is valid, with 0 lint errors").