### PR TITLE
Surface error for missing $ref

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -79,7 +79,7 @@ const readOrError = async (file, options = {}) => {
             console.error('Could not read YAML/JSON from file: ' + error.message);
         }
         else {
-            console.error(error);
+            console.error(error.message);
         }
         process.exit(1);
     }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -13,6 +13,8 @@ const green = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[32m';
 const yellow = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[33;1m';
 const normal = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[0m';
 
+class MissingRefError extends Error {}
+
 function unique(arr) {
     return [...new Set(arr)];
 }
@@ -138,7 +140,7 @@ function resolveExternal(root, pointer, options, callback) {
         return Promise.resolve(data);
     }
 
-    if (options.verbose) {
+    if (options.verbose > 1) {
         console.log('GET', target, fragment);
     }
 
@@ -152,8 +154,10 @@ function resolveExternal(root, pointer, options, callback) {
                 callback(data, target, options);
                 return data;
             })
-            .catch(ex => {
-                if (options.verbose) console.warn(ex);
+            .catch(err => {
+                return Promise.reject(
+                    new MissingRefError('Invalid $ref, pointing to a missing or inaccessable file: ' + err.message)
+                );
             });
     }
     else if (u.protocol && u.protocol.startsWith('http')) {
@@ -179,17 +183,17 @@ function resolveExternal(root, pointer, options, callback) {
                     }
                     data = resolveAllInternal(data, context, pointer, fragment, target, options);
                 }
-                catch (ex) {
-                    if (!options.verbose) console.warn('GET', target, fragment);
-                    console.warn(ex);
+                catch (err) {
+                    return Promise.reject(err);
                 }
                 callback(data, target, options);
                 return data;
             })
-            .catch(function (err) {
-                if (options.verbose) console.warn(err);
+            .catch(err => {
                 options.cache[target] = {};
-                if (options.promise && options.fatal) options.promise.reject(err);
+                return Promise.reject(
+                    new MissingRefError('Invalid $ref, pointing to a missing or inaccessable file: ' + err.message)
+                );
             });
     }
     else {
@@ -214,17 +218,17 @@ function resolveExternal(root, pointer, options, callback) {
                     }
                     data = resolveAllInternal(data, context, pointer, fragment, target, options);
                 }
-                catch (ex) {
-                    if (!options.verbose) console.warn('GET', target, fragment);
-                    console.warn(ex);
+                catch (err) {
+                    return Promise.reject(err);
                 }
                 callback(data, target, options);
                 return data;
             })
-            .catch(function(err){
-                if (options.verbose) console.warn(err);
+            .catch(err => {
                 options.cache[target] = {};
-                if (options.promise && options.fatal) options.promise.reject(err);
+                return Promise.reject(
+                    new MissingRefError('Invalid $ref, pointing to a missing or inaccessable file: ' + err.message)
+                );
             });
     }
 }
@@ -270,8 +274,7 @@ function scanExternalRefs(options) {
 }
 
 function findExternalRefs(options) {
-    return new Promise(function (res) {
-
+    return new Promise(function (resolve, reject) {
         scanExternalRefs(options)
             .then(refs => {
                 for (const ref in refs) {
@@ -301,17 +304,13 @@ function findExternalRefs(options) {
                                 }
 
                                 let localOptions = Object.assign({}, options, {
- source: '',
+                                    source: '',
                                     resolver: {
-actions: options.resolver.actions,
-                                    depth: options.resolver.actions.length-1,
-base: options.resolver.base
-}
-});
-                                if (options.patch && refs[ref].description && !data.description &&
-                                    (typeof data === 'object')) {
-                                    data.description = refs[ref].description;
-                                }
+                                        actions: options.resolver.actions,
+                                        depth: options.resolver.actions.length-1,
+                                        base: options.resolver.base
+                                    }
+                                });
                                 refs[ref].data = data;
                                 let pointers = unique(refs[ref].paths).sort(function(a,b){
                                     if (a.length < b.length) return -1;
@@ -337,7 +336,6 @@ base: options.resolver.base
                                     }
                                 }
                                 if (options.resolver.actions[localOptions.resolver.depth].length === 0) {
-                                    //options.resolver.actions[localOptions.resolver.depth].push(function () { return scanExternalRefs(localOptions) });
                                     options.resolver.actions[localOptions.resolver.depth].push(function () { return findExternalRefs(localOptions) }); // findExternalRefs calls scanExternalRefs
                                 }
                             });
@@ -345,13 +343,15 @@ base: options.resolver.base
                     }
                 }
             })
-            .catch(ex => {
-                if (options.verbose) console.warn(ex);
+            .catch(err => {
+                if (options.verbose > 1) console.warn(err);
+                reject(err);
             });
 
-        let result = {options:options};
-        result.actions = options.resolver.actions[options.resolver.depth];
-        res(result);
+        resolve({
+            options: options,
+            actions: options.resolver.actions[options.resolver.depth]
+        });
     });
 }
 
@@ -382,12 +382,14 @@ const loopReferences = (options, res, rej) => {
                         }
                     }
                 })
-                .catch(ex => {
-                    if (options.verbose) console.warn(ex);
+                .catch(err => {
+                    if (options.verbose > 1) console.warn(err);
+                    rej(err);
                 });
         })
-        .catch(ex => {
-            if (options.verbose) console.warn(ex);
+        .catch(err => {
+            if (options.verbose > 1) console.warn(err);
+            rej(err);
         });
 }
 

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -31,7 +31,7 @@ describe('validator.js', () => {
                         validator.validate(spec, {}, err => {
                             done(err);
                         });
-                    });
+                    }).catch(err => done(err));
                 });
             });
         });
@@ -47,6 +47,8 @@ describe('validator.js', () => {
                             if (err) return done();
                             done(new Error('no validation error'));
                         });
+                    }).catch(err => {
+                        if (err) return done();
                     });
                 });
             });

--- a/test/validator/fail/externalPathItemRef.yaml
+++ b/test/validator/fail/externalPathItemRef.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+
+tags:
+    - name: foo
+
+info:
+    title: Test invalid external $ref of PathItem
+    version: 1.0.0
+    contact:
+        name: Bob
+
+servers:
+    - url: https://acme.com/api/v1
+
+paths:
+    /test:
+        $ref: 'missing.yaml#/paths/someresource'


### PR DESCRIPTION
Fixes #53 

A $ref to a missing file would show up in verbose mode, but was not causing the error that speccy users would expect. This PR removes some promise logic thats a layover from the swagger2openapi codebase, and rejects files that are not found. 

```
$ node speccy resolve test/validator/fail/externalPathItemRef.yaml
Invalid $ref, pointing to a missing or inaccessable file: ENOENT: no such file or directory, open 'test/validator/fail/missing.yaml'

$ node speccy lint test/validator/fail/externalPathItemRef.yaml
Invalid $ref, pointing to a missing or inaccessable file: ENOENT: no such file or directory, open 'test/validator/fail/missing.yaml'

$ node speccy serve test/validator/fail/externalPathItemRef.yaml
Invalid $ref, pointing to a missing or inaccessable file: ENOENT: no such file or directory, open 'test/validator/fail/missing.yaml'
```