### PR TITLE
JSON Schema Walker doesn't know about arbitrary keywords

### DIFF
--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -20,7 +20,7 @@ const fetchTestFiles = dir => {
 
 describe('validator.js', () => {
     describe('validate()', () => {
-        const options = { resolve: true };
+        const options = { resolve: true, jsonSchema: true };
 
         context('when provided valid specifications', () => {
             const samplesPath = path.join(__dirname, './validator/pass');

--- a/test/validator/pass/issue-70/include/def.json
+++ b/test/validator/pass/issue-70/include/def.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "definitions": {
+  "properties": {
     "foobar": {
       "type": ["string", "null"]
     }

--- a/test/validator/pass/issue-70/include/def.json
+++ b/test/validator/pass/issue-70/include/def.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "foobar": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/test/validator/pass/issue-70/openapi.yaml
+++ b/test/validator/pass/issue-70/openapi.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Test
+components:
+  schemas:
+    $ref: ./include/def.json
+paths:
+  /:
+    get:
+      parameters:
+        - name: foobar
+          in: query
+          schema:
+            $ref: ./include/def.json#/definitions/foobar

--- a/test/validator/pass/issue-70/openapi.yaml
+++ b/test/validator/pass/issue-70/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: Test
 components:
   schemas:
-    $ref: ./include/def.json
+    $ref: ./include/def.json#/properties
 paths:
   /:
     get:
@@ -12,4 +12,7 @@ paths:
         - name: foobar
           in: query
           schema:
-            $ref: ./include/def.json#/definitions/foobar
+            $ref: ./include/def.json#/properties/foobar
+      responses:
+        200:
+          description: yay


### PR DESCRIPTION
A possible bug outlined in #70, where json-schema-walker is not getting to specific properties.