### PR TITLE
More useful error output for type mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Fixed
+- Fix `message is undefined` error ([#78])
 - Resolver was treating `$ref` with a URL like a file. ([#80])
 
+[#78]: https://github.com/wework/speccy/pull/78
 [#80]: https://github.com/wework/speccy/pull/80
 
 ## [0.7.1] - 2018-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix `message is undefined` error ([#78])
 - Resolver was treating `$ref` with a URL like a file. ([#80])
+- Show more useful validation warnings when certain properties are the incorrect type. ([#83])
 
 [#78]: https://github.com/wework/speccy/pull/78
 [#80]: https://github.com/wework/speccy/pull/80
+[#83]: https://github.com/wework/speccy/pull/83
 
 ## [0.7.1] - 2018-05-17
 ### Fixed

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -119,27 +119,27 @@ function checkSubSchema(schema, parent, state) {
     }
 
     if (schema.multipleOf) {
-        schema.multipleOf.should.be.a.Number();
+        schema.multipleOf.should.be.type(Number, 'multipleOf should be a number');
         schema.multipleOf.should.be.greaterThan(0);
     }
     if (schema.maximum) {
-        schema.maximum.should.be.a.Number();
+        schema.maximum.should.be.type(Number, 'maximum should be a number');
     }
     if (schema.exclusiveMaximum) {
-        schema.exclusiveMaximum.should.be.a.Boolean();
+        schema.exclusiveMaximum.should.be.type(Boolean, 'exclusiveMaximum should be a boolean');
     }
     if (schema.minimum) {
-        schema.minimum.should.be.a.Number();
+        schema.minimum.should.be.type(Number, 'minimum should be a number');
     }
     if (schema.exclusiveMinimum) {
-        schema.exclusiveMinimum.should.be.a.Boolean();
+        schema.exclusiveMinimum.should.be.type(Boolean, 'exclusiveMinimum should be a boolean');
     }
     if (schema.maxLength) {
-        schema.maxLength.should.be.a.Number();
+        schema.maxLength.should.be.type(Number, 'maxLength should be a number');
         schema.maxLength.should.be.greaterThan(-1);
     }
     if (schema.minLength) {
-        schema.minLength.should.be.a.Number();
+        schema.minLength.should.be.type(Number, 'minLength should be a number');
         schema.minLength.should.be.greaterThan(-1);
     }
     if (schema.pattern) {
@@ -158,7 +158,7 @@ function checkSubSchema(schema, parent, state) {
         if (typeof schema.additionalItems === 'boolean') {
         }
         else if (typeof schema.additionalItems === 'object') {
-            schema.additionalItems.should.not.be.an.Array();
+            schema.additionalItems.should.not.be.instanceOf(Array, 'additionalItems should not be an array, it shoud be a boolean or schema');
         }
         else should.fail(false,true,'additionalItems must be a boolean or schema');
     }
@@ -166,50 +166,39 @@ function checkSubSchema(schema, parent, state) {
         if (typeof schema.additionalProperties === 'boolean') {
         }
         else if (typeof schema.additionalProperties === 'object') {
-            schema.additionalProperties.should.not.be.an.Array();
+            schema.additionalProperties.should.not.be.instanceOf(Array, 'additionalProperties should not be an array, it should be a boolean or schema');
         }
         else should.fail(false,true,'additionalProperties must be a boolean or schema');
     }
     if (schema.maxItems) {
-        schema.maxItems.should.be.a.Number();
+        schema.maxItems.should.be.type(Number, 'maxItems should be a number');
         schema.maxItems.should.be.greaterThan(-1);
     }
     if (schema.minItems) {
-        schema.minItems.should.be.a.Number();
+        schema.minItems.should.be.type(Number, 'minItems should be a number');
         schema.minItems.should.be.greaterThan(-1);
     }
     if (typeof schema.uniqueItems !== 'undefined') {
         schema.uniqueItems.should.be.a.Boolean();
     }
     if (schema.maxProperties) {
-        schema.maxProperties.should.be.a.Number();
+        schema.maxProperties.should.be.type(Number, 'maxProperties should be a number');
         schema.maxProperties.should.be.greaterThan(-1);
     }
     if (schema.minProperties) {
-        schema.minProperties.should.be.a.Number();
+        schema.minProperties.should.be.type(Number, 'minProperties should be a number');
         schema.minProperties.should.be.greaterThan(-1);
     }
     if (typeof schema.required !== 'undefined') {
-        schema.required.should.be.an.Array();
+        schema.required.should.be.instanceOf(Array, 'required should be an array');
         schema.required.should.not.be.empty();
         common.hasDuplicates(schema.required).should.be.exactly(false,'required items must be unique');
     }
     if (schema.properties) {
         schema.properties.should.be.an.Object();
-        schema.properties.should.not.be.an.Array();
+        schema.properties.should.not.be.instanceOf(Array, 'properties should not be an array');
     }
     schema.should.not.have.property('patternProperties');
-    /*if (schema.patternProperties) {
-        schema.patternProperties.should.be.an.Object();
-        for (let prop in schema.patternProperties) {
-            try {
-                let regex = new RegExp(prop);
-            }
-            catch (ex) {
-                should.fail(false,true,'patternProperty '+prop+' does not conform to ECMA-262');
-            }
-        }
-    }*/
     if (typeof schema.enum !== 'undefined') {
         schema.enum.should.be.an.Array();
         schema.enum.should.not.be.empty();
@@ -271,18 +260,18 @@ function checkSubSchema(schema, parent, state) {
     }
 
     if (typeof schema.nullable !== 'undefined') {
-        schema.nullable.should.be.a.Boolean();
+        schema.nullable.should.be.type(Boolean, 'nullable should be a boolean');
     }
     if (typeof schema.readOnly !== 'undefined') {
-        schema.readOnly.should.be.a.Boolean();
+        schema.readOnly.should.be.type(Boolean, 'readOnly should be a boolean');
         schema.should.not.have.property('writeOnly');
     }
     if (typeof schema.writeOnly !== 'undefined') {
-        schema.writeOnly.should.be.a.Boolean();
+        schema.writeOnly.should.be.type(Boolean, 'writeOnly should be a boolean');
         schema.should.not.have.property('readOnly');
     }
     if (typeof schema.deprecated !== 'undefined') {
-        schema.deprecated.should.be.a.Boolean();
+        schema.deprecated.should.be.type(Boolean, 'deprecated should be a boolean');
     }
     if (typeof schema.discriminator !== 'undefined') {
         schema.discriminator.should.be.an.Object();

--- a/test/validator/fail/requiredTrue.yaml
+++ b/test/validator/fail/requiredTrue.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.1
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /:
+    get:
+      parameters:
+        - name: test
+          in: query
+          schema:
+            type: string
+            required: true
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Due to limitations with how should.js works, the type mismatches are currently giving rather confusing error messages. 

```
#/paths/~1/get/parameters/0/schema
expected true to be an array
    expected true to have [[Class]] Array
```

That is no good, as it doesn't mention _which_ property is true instead of being an array.

So! Instead lets make our own messages. Now it says:

```
#/paths/~1/get/parameters/0/schema
required should be an array
```

Simple, to the point, and when combined with #54 this'll be all the information anyone could need.