### PR TITLE
Config File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Config files can be passed with `-c` (defaults to `speccy.yaml`). See [README](./README.md) for more informaton
 ### Changed
 - Switched to using [oas-kit](https://github.com/Mermade/oas-kit/) for resolving and validating.
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ If you want to run speccy on OpenAPI (f.k.a Swagger) v2.0 specs, run it through 
 ```
 Usage: speccy <command>
 
+
 Options:
 
-  -V, --version  output the version number
-  -h, --help     output usage information
+-V, --version              output the version number
+-c, --config [configFile]  config file (containing JSON/YAML). See README for potential values.
+-h, --help                 output usage information
+
 
 Commands:
 
-  lint [options] <file-or-url>     ensure specs are not just valid OpenAPI, but lint against specified rules
-  resolve [options] <file-or-url>  pull in external $ref files to create one mega-file
-  serve [options] <file-or-url>    view specifications in beautiful human readable documentation
+lint [options] <file-or-url>     ensure specs are not just valid OpenAPI, but lint against specified rules
+resolve [options] <file-or-url>  pull in external $ref files to create one mega-file
+serve [options] <file-or-url>    view specifications in beautiful human readable documentation
 ```
 
 ### Lint Command
@@ -117,10 +120,40 @@ Options:
   -h, --help          output usage information
 ```
 
+### Config File
+
+To avoid needing to send command line options and switches every time, a config file can be used. Create
+a `speccy.yaml` in the root of your project.
+
+Example:
+```yaml
+# Convert JSON Schema-proper to OpenAPI-flavoured Schema Objects
+jsonSchema: true
+# Keep the noise down
+quiet: true
+# Output a lot of information about what is happening (wont work if you have quiet on)
+verbose: true
+# Rules specific to the lint command
+lint:
+  # rules files to load
+  rules:
+  - strict
+  - ./some/local/rules.json
+  - https://example.org/my-rules.json
+  # rules to skip
+  skip:
+  - info-contact
+# Rules specific to the resolve command
+resolve:
+  output: foo.yaml
+# Rules specific to the serve command
+serve:
+  port: 8001
+```
+
 ### Calling Speccy from Code
 
 Not just a command line tool, speccy can be used to normalize machine-readable specifications.
-
 
 The loader object will return a promise that resolves to an object containing
 the specification.  For example:

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// TODO See if this can be removed now oas-kit is in use
+
 const recurse = require('reftools/lib/recurse.js').recurse;
 const resolveInternal = require('reftools/lib/jptr.js').jptr;
 const clone = require('reftools/lib/clone.js').clone;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const nconf = require('nconf');
+
+nconf.formats.yaml = require('nconf-yaml');
+
+class Config {
+
+    init(args) {
+        const configFile = args.config || './speccy.yaml';
+
+        this.load(configFile, {
+            quiet: args.quiet,
+            jsonSchema: args.jsonSchema,
+            verbose: args.verbose,
+            // Command specific options
+            lint: {
+                rules: args.rules,
+                skip: args.skip,
+            },
+            resolve: {
+                output: args.output,
+            },
+            serve: {
+                port: args.port,
+            }
+        });
+    }
+
+    load(file, supplied) {
+        // 1, check the supplied values
+        nconf.add('supplied', {
+            type: 'literal',
+            store: this.cleanObject(supplied),
+        });
+
+        // 2, look in config file (e.g: speccy.yaml)
+        nconf.add('local', {
+            type: 'file',
+            format: nconf.formats.yaml,
+            file,
+        });
+    }
+
+    get(key, defaultValue) {
+        // Search through all known stores for the value
+        const value = nconf.get(key);
+        return (value === undefined) ? defaultValue : value;
+    }
+
+    // Don't want an object full of null
+    cleanObject(object) {
+        const cleaned = {};
+        Object.keys(object).forEach(key => {
+            const value = object[key];
+            if (value === undefined || value === null) {
+                return;
+            } else if (typeof value === "object") {
+                return cleaned[key] = this.cleanObject(value);
+            } else {
+                cleaned[key] = value;
+            }
+        });
+        return cleaned;
+    }
+}
+
+module.exports = new Config;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -47,7 +47,7 @@ const relevantRules = skipRules => {
     return rules.filter(rule => skipRules.indexOf(rule.name) === -1);
 }
 
-const lint = (objectName, object, options = {}) => {
+const lint = (objectName, object, key, options = {}) => {
     const { skip } = options;
 
     const rules = relevantRules(skip);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -21,7 +21,7 @@ const ensureRule = (context, rule, shouldAssertion) => {
 
 let activeRules = {};
 
-const initialize = () => {
+const init = () => {
     activeRules = {};
 };
 
@@ -193,6 +193,6 @@ const lint = (objectName, object, key, options = {}) => {
 module.exports = {
     createNewRule,
     createNewRules,
-    initialize,
+    init,
     lint,
 };

--- a/lint.js
+++ b/lint.js
@@ -71,6 +71,7 @@ const command = async (specFile, cmd) => {
     const rulesFiles = config.get('lint:rules');
     const skip = config.get('lint:skip');
 
+    linter.init();
     await loader.loadRuleFiles(rulesFiles, { verbose });
 
     const spec = await loader.readOrError(

--- a/lint.js
+++ b/lint.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const config = require('./lib/config.js');
 const loader = require('./lib/loader.js');
 const linter = require('./lib/linter.js');
 const validator = require('oas-validator');
@@ -63,38 +64,32 @@ More information: https://speccy.io/rules/#${rule.name}
     return output;
 }
 
-const command = async (file, cmd) => {
-    const verbose = cmd.quiet ? -1 : cmd.verbose;
+const command = async (specFile, cmd) => {
+    config.init(cmd);
+    const jsonSchema = config.get('jsonSchema');
+    const verbose = config.get('quiet') ? -1 : config.get('verbose');
+    const rulesFiles = config.get('lint:rules');
+    const skip = config.get('lint:skip');
 
-    linter.initialize();
+    await loader.loadRuleFiles(rulesFiles, { verbose });
 
-    await loader.loadRuleFiles(cmd.rules, { verbose });
+    const spec = await loader.readOrError(
+        specFile,
+        buildLoaderOptions(jsonSchema, verbose),
+    );
 
-    let filters = [];
-    if (cmd.jsonSchema) {
-        filters.push(fromJsonSchema);
-    }
-
-    const spec = await loader.readOrError(file, {
-        resolve: true,
-        filters,
-        verbose
-    });
-
-    validator.validate(spec, { verbose, skip: cmd.skip, lint: true, linter: linter.lint, prettify: true }, (err, _options) => {
+    validator.validate(spec, buildValidatorOptions(skip, verbose), (err, _options) => {
         const { context, lintResults } = _options;
 
         if (err) {
             console.error(colors.red + 'Specification schema is invalid.' + colors.reset);
-            const output = formatSchemaError(err, context);
-            console.error(output);
+            console.error(formatSchemaError(err, context));
             process.exit(1);
         }
 
         if (lintResults.length) {
             console.error(colors.red + 'Specification contains lint errors: ' + lintResults.length + colors.reset);
-            const output = formatLintResults(lintResults);
-            console.warn(output)
+            console.warn(formatLintResults(lintResults))
             process.exit(1);
         }
 
@@ -105,4 +100,28 @@ const command = async (file, cmd) => {
     });
 };
 
-module.exports = { command }
+const buildLoaderOptions = (jsonSchema, verbose) => {
+    const options = {
+        filters: [],
+        resolve: true,
+        verbose,
+    };
+
+    if (jsonSchema) {
+        options.filters.push(fromJsonSchema);
+    }
+
+    return options;
+}
+
+const buildValidatorOptions = (skip, verbose) => {
+    return {
+        skip,
+        lint: true,
+        linter: linter.lint,
+        prettify: true,
+        verbose,
+    };
+}
+
+module.exports = { command };

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1667,6 +1672,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -2088,6 +2098,95 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nconf": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "requires": {
+        "async": "^1.4.0",
+        "ini": "^1.3.0",
+        "secure-keys": "^1.0.0",
+        "yargs": "^3.19.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
+    "nconf-yaml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nconf-yaml/-/nconf-yaml-1.0.2.tgz",
+      "integrity": "sha1-/qBlMzz0K3el6AYFF5aXmdQVZXU=",
+      "requires": {
+        "js-yaml": "^3.2.3"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -5488,6 +5587,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -5882,6 +5986,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",
     "json-schema-to-openapi-schema": "^0.2.0",
+    "nconf": "^0.10.0",
+    "nconf-yaml": "^1.0.2",
     "node-fetch": "^1.7.3",
     "node-readfiles": "^0.2.0",
     "oas-resolver": "^1.0.7",

--- a/resolve.js
+++ b/resolve.js
@@ -4,39 +4,43 @@
 
 const fs = require('fs');
 const yaml = require('js-yaml');
+const config = require('./lib/config.js');
 const loader = require('./lib/loader.js');
 const resolver = require('oas-resolver');
 const fromJsonSchema = require('json-schema-to-openapi-schema');
 
-const options = {
-    resolve: true,
-    cache: [],
-    externals: [],
-    externalRefs: {},
-    rewriteRefs: true,
-    status: 'undefined',
-};
-
 const command = async (file, cmd) => {
-    options.filters = [];
-    if (cmd.jsonSchema) {
-        options.filters.push(fromJsonSchema);
-    }
-    options.verbose = cmd.quiet ? -1 : cmd.verbose;
+    config.init(cmd);
+    const jsonSchema = config.get('jsonSchema');
+    const output = config.get('resolve:output');
+    const verbose = config.get('quiet') ? -1 : config.get('verbose');
 
-    const spec = await loader.readOrError(file, options);
+    const spec = await loader.readOrError(file, buildLoaderOptions(jsonSchema, verbose));
     const content = yaml.safeDump(spec, { lineWidth: -1 });
 
-    if (cmd.output) {
-        fs.writeFile(cmd.output, content, 'utf8', () => {
-            if (options.verbose > 1) {
-                console.log('Resolved to ' + cmd.output);
-            }
+    if (output) {
+        fs.writeFile(output, content, 'utf8', () => {
+            if (verbose) console.log('Resolved to ' + output);
         });
+        return;
     }
-    else {
-        console.log(content);
-    }
+
+    console.log(content);
 };
+
+const buildLoaderOptions = (jsonSchema, verbose) => {
+    const options = {
+        resolve: true,
+        cache: [],
+        externals: [],
+        externalRefs: {},
+        rewriteRefs: true,
+        status: 'undefined',
+        filters: [],
+        verbose: verbose,
+    };
+    if (jsonSchema) options.filters.push(fromJsonSchema);
+    return options;
+}
 
 module.exports = { command }

--- a/speccy.js
+++ b/speccy.js
@@ -17,7 +17,8 @@ function collect(val, item) {
 
 program
     .version(version)
-    .usage('<command>');
+    .usage('<command>')
+    .option('-c, --config [configFile]', 'config file (containing JSON/YAML). See README for potential values.');
 
 program
     .command('lint <file-or-url>')
@@ -25,8 +26,8 @@ program
     .option('-q, --quiet', 'reduce verbosity')
     .option('-r, --rules [ruleFile]', 'provide multiple rules files', collect, [])
     .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
-    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
-    .option('-v, --verbose', 'increase verbosity', 2)
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-v, --verbose', 'increase verbosity')
     .action(lint.command);
 
 program
@@ -34,17 +35,17 @@ program
     .description('pull in external $ref files to create one mega-file')
     .option('-o, --output <file>', 'file to output to')
     .option('-q, --quiet', 'reduce verbosity')
-    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
-    .option('-v, --verbose', 'increase verbosity', 2)
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-v, --verbose', 'increase verbosity')
     .action(resolve.command);
 
 program
     .command('serve <file-or-url>')
     .description('view specifications in beautiful human readable documentation')
-    .option('-p, --port [value]', 'port on which the server will listen', 5000)
+    .option('-p, --port [value]', 'port on which the server will listen (default: 5000)')
     .option('-q, --quiet', 'reduce verbosity')
-    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects')
-    .option('-v, --verbose', 'increase verbosity', 2)
+    .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-v, --verbose', 'increase verbosity')
     // TODO .option('-w, --watch', 'reloading browser on spec file changes')
     .action(serve.command);
 

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -2,7 +2,7 @@
 
 const common = require('../lib/common.js');
 
-describe('common.js', () => {
+describe('Common', () => {
     describe('hasDuplicates()', () => {
         it('considers [a, b, c] to not contain duplicates', () => {
             should(common.hasDuplicates(['a', 'b', 'c'])).be.eql(false);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const config = require('../lib/config.js');
+
+describe('Config', () => {
+    describe('init()', () => {
+        it('does not throw for invalid file', () => {
+            const configFile = 'test/config/doesnotexist.yaml';
+            should.doesNotThrow(() => { config.init({ config: configFile }); });
+        });
+
+        context('with a valid yaml file', () => {
+            const configFile = 'test/config/valid.yaml';
+
+            it('can find expected values', () => {
+                config.init({ config: configFile });
+
+                should(config.get('jsonSchema')).be.eql(true);
+                should(config.get('serve:port')).be.eql(8001);
+            });
+        });
+
+        context('with a valid json file', () => {
+            const configFile = 'test/config/valid.json';
+
+            it('can find expected values', () => {
+                config.init({ config: configFile });
+
+                should(config.get('jsonSchema')).be.eql(true);
+                should(config.get('serve:port')).be.eql(8001);
+            });
+        });
+    });
+
+    describe('load()', () => {
+        context('when an empty file is loaded', () => {
+            const configFile = 'test/config/empty.yaml';
+
+            context('and no config options are supplied', () => {
+                it('it will have undefined values', () => {
+                    config.load(configFile, {});
+                    should(config.get('foo:bar')).be.undefined;
+                });
+            });
+
+            context('and config options are supplied', () => {
+                it('with an empty file', () => {
+                    config.load(configFile, { foo: { bar: 123 }});
+                    should(config.get('foo:bar')).be.eql(123);
+                });
+            });
+        });
+    });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -9,8 +9,8 @@ describe('Config', () => {
             should.doesNotThrow(() => { config.init({ config: configFile }); });
         });
 
-        context('with a valid yaml file', () => {
-            const configFile = 'test/config/valid.yaml';
+        context('with a valid json file', () => {
+            const configFile = 'test/config/valid.json';
 
             it('can find expected values', () => {
                 config.init({ config: configFile });
@@ -20,14 +20,22 @@ describe('Config', () => {
             });
         });
 
-        context('with a valid json file', () => {
-            const configFile = 'test/config/valid.json';
+        context('with a valid yaml file', () => {
+            const configFile = 'test/config/valid.yaml';
 
             it('can find expected values', () => {
                 config.init({ config: configFile });
 
                 should(config.get('jsonSchema')).be.eql(true);
                 should(config.get('serve:port')).be.eql(8001);
+            });
+
+            it('will handle array config items', () => {
+                should(config.get('lint:rules')).be.eql([
+                    'strict',
+                    './some/local/rules.json',
+                    'https://example.org/my-rules.json',
+                ]);
             });
         });
     });

--- a/test/config/valid.json
+++ b/test/config/valid.json
@@ -1,0 +1,21 @@
+{
+    "jsonSchema": true,
+    "quiet": true,
+    "verbose": true,
+    "lint": {
+      "rules": [
+        "strict",
+        "./some/local/rules.json",
+        "https://example.org/my-rules.json"
+      ],
+      "skip": [
+        "info-contact"
+      ]
+    },
+    "resolve": {
+      "output": "foo.yaml"
+    },
+    "serve": {
+      "port": 8001
+    }
+  }

--- a/test/config/valid.yaml
+++ b/test/config/valid.yaml
@@ -1,0 +1,22 @@
+# Convert JSON Schema-proper to OpenAPI-flavoured Schema Objects
+jsonSchema: true
+# Keep the noise down
+quiet: true
+# Output a lot of information about what is happening (wont work if you have quiet on)
+verbose: true
+# Rules specific to the lint command
+lint:
+  # rules files to load
+  rules:
+  - strict
+  - ./some/local/rules.json
+  - https://example.org/my-rules.json
+  # rules to skip
+  skip:
+  - info-contact
+# Rules specific to the resolve command
+resolve:
+  output: foo.yaml
+# Rules specific to the serve command
+serve:
+  port: 8001

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -18,7 +18,7 @@ const testFixture = (fixture, rules) => {
         const { input, expectedRuleErrors, expectValid, skip = [] } = test;
 
         // Reset rules
-        linter.initialize();
+        linter.init();
 
         loader.loadRuleFiles(rules).then(() => {
             const actualRuleErrors = getLinterErrors(runLinter(fixture.object, input, { skip }));
@@ -61,13 +61,13 @@ describe('Linter', () => {
 
         context('when rules are manually passed', () => {
             const lintAndExpectErrors = (rule, input, expectedErrors) => {
-                linter.initialize();
+                linter.init();
                 linter.createNewRule(rule);
                 getLinterErrors(runLinter('something', input)).should.be.deepEqual(expectedErrors);
             }
 
             const lintAndExpectValid = async (rule, input) => {
-                linter.initialize();
+                linter.init();
                 linter.createNewRule(rule);
                 getLinterErrors(runLinter('something', input)).should.be.empty();
             }

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -43,7 +43,7 @@ const testFixture = (fixture, rules) => {
     });
 }
 
-describe('linter.js', () => {
+describe('Linter', () => {
     describe('lint()', () => {
         const profilesDir = path.join(__dirname, './profiles/');
 

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -5,8 +5,8 @@ const path = require('path');
 const loader = require('../lib/loader.js');
 const linter = require('../lib/linter.js');
 
-const runLinter = (object, input, options = {}) => {
-    return linter.lint(object, input, options);
+const runLinter = (object, input, key, options = {}) => {
+    return linter.lint(object, input, key, options);
 }
 
 const getLinterErrors = linter => {
@@ -15,13 +15,13 @@ const getLinterErrors = linter => {
 
 const testFixture = (fixture, rules) => {
     fixture.tests.forEach(test => {
-        const { input, expectedRuleErrors, expectValid, skip = [] } = test;
+        const { input, expectedRuleErrors, expectValid, key, skip = [] } = test;
 
         // Reset rules
         linter.init();
 
         loader.loadRuleFiles(rules).then(() => {
-            const actualRuleErrors = getLinterErrors(runLinter(fixture.object, input, { skip }));
+            const actualRuleErrors = getLinterErrors(runLinter(fixture.object, input, key, { skip }));
             if (expectValid) {
                 var msg = JSON.stringify(input) + ' is valid';
                 var assertion = () => actualRuleErrors.should.be.empty('expected no linter errors, but got some');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -7,7 +7,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const fromJsonSchema = require('json-schema-to-openapi-schema');
 
-describe('loader.js', () => {
+describe('Loader', () => {
     describe('loadRuleFiles()', () => {
         it('load default rules', () => {
             loader.loadRuleFiles(['default']).should.be.fulfilledWith(['default']);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2,9 +2,11 @@
 
 const server = require('../lib/server.js');
 
-describe('loadHTML()', () => {
-    it('is a string', () => {
-        const html = server.loadHTML();
-        should(html).be.String();
+describe('Server', () => {
+    describe('loadHTML()', () => {
+        it('is a string', () => {
+            const html = server.loadHTML();
+            should(html).be.String();
+        });
     });
 });


### PR DESCRIPTION
Based off of the release/0.8.0 as the oas-kit changes were rather substantial. 

This builds on top of #93, fixing #14, giving the user a basic config file so they do not need to pass the darn CLI options every single time. 

The approach uses nconf, which is a much less opinionated alternative to node-config. Seeing as node-config forces file structure and file names, we could not figure out how to get `speccy.json`, and that killed the whole approach.

Quick poll in the comments below, please vote.