### PR TITLE
Enabled path-keys-no-trailing-slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Config files can be passed with `-c` (defaults to `speccy.yaml`). See [README](./README.md) for more informaton
+- Enabled `path-keys-no-trailing-slash` now oas-resolver can handle keys for lint rules
 ### Changed
-- Switched to using [oas-kit](https://github.com/Mermade/oas-kit/) for resolving and validating.
-
+- Switched to using [oas-kit](https://github.com/Mermade/oas-kit/) for resolving and validating
 
 ## [0.7.3] - 2018-06-19
 ### Added

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -166,10 +166,13 @@ const lint = (objectName, object, key, options = {}) => {
                 }
             }
             if (rule.notEndWith) {
-                const { value, property } = rule.notEndWith;
-                ensure(rule, () => {
-                    should(object[property]).not.endWith(value);
-                });
+                const { value } = rule.notEndWith;
+                let property = (rule.notEndWith.property === '$key') ? key : rule.notEndWith.property;
+                if (object[property] && (typeof object[property] === 'string')) {
+                    ensure(rule, () => {
+                        should(object[property]).not.endWith(value);
+                    });
+                }
             }
             if (rule.maxLength) {
                 const { value, property } = rule.maxLength;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -166,11 +166,14 @@ const lint = (objectName, object, key, options = {}) => {
                 }
             }
             if (rule.notEndWith) {
-                const { value } = rule.notEndWith;
-                let property = (rule.notEndWith.property === '$key') ? key : rule.notEndWith.property;
-                if (object[property] && (typeof object[property] === 'string')) {
+                const { omit, property, value } = rule.notEndWith;
+                let propertyValue = (property === '$key') ? key : object[property];
+                if (typeof propertyValue === 'string') {
+                    if (omit) {
+                        propertyValue = propertyValue.replace(omit,'');
+                    }
                     ensure(rule, () => {
-                        should(object[property]).not.endWith(value);
+                        propertyValue.should.not.endWith(value);
                     });
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+      "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
       "requires": {
-        "@babel/highlight": "7.0.0-beta.51"
+        "@babel/highlight": "7.0.0-beta.53"
       }
     },
     "@babel/generator": {
@@ -63,9 +63,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+      "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -121,6 +121,63 @@
         "@babel/parser": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
         "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
@@ -141,11 +198,66 @@
         "lodash": "^4.17.5"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "globals": {
           "version": "11.7.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -3488,9 +3600,9 @@
       "integrity": "sha512-likga5DU40ahQBlLuPMoahlzckhsfbKAPaghgHRxmG0N98W7XQMlosMkNAkVAsze7D+xczcUETUhEpNgaOzJ0g=="
     },
     "oas-linter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-1.0.4.tgz",
-      "integrity": "sha512-ajxYV/x90Tv0wBkdI3eiXpjbNf73WD4mPi3jLOKAiUJGufNEPOodflNJ8BQocgDQfyt5UwZRayNzNifrczTsOA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-1.0.6.tgz",
+      "integrity": "sha512-U/PO2w6RSm2VbRtzD1ZT5oGrRBnPghDy0QF5sX/nlQoX83vi0r4ZweLkOf56LIEaNZIX63UO7D1r1Yvf6IPdeA==",
       "requires": {
         "js-yaml": "^3.11.0",
         "should": "^13.2.1"
@@ -3546,15 +3658,15 @@
       "integrity": "sha512-l8DzGboYf+3ApbQVdr7sAETzuGGUpIXlj8lsievV+N2R1HStn3ecMUeDUjbyXd4y7Rhyhrhh5UiQJjMX1fuYKQ=="
     },
     "oas-validator": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-1.1.5.tgz",
-      "integrity": "sha512-Vz5unJEeD94Rx05zks/ivp8sDowrnb1mxAROrzu5FUqYRG3oGHZ3XUe9P62SPkhajOckW7VxrOOUmTyX6lh3Uw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-1.1.7.tgz",
+      "integrity": "sha512-DABnt75JPsuti7y0Xlb7iXEs8s1JWxYDsVfClJFj8qfmruL4/JqVMcb1gqya9v/OBgMpIBwHVhl/GXxx6oa2nA==",
       "requires": {
         "ajv": "^5.5.2",
         "better-ajv-errors": "^0.5.1",
         "js-yaml": "^3.11.0",
         "oas-kit-common": "^1.0.3",
-        "oas-linter": "^1.0.4",
+        "oas-linter": "^1.0.6",
         "oas-resolver": "^1.0.8",
         "oas-schema-walker": "^1.0.4",
         "reftools": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-readfiles": "^0.2.0",
     "oas-resolver": "^1.0.7",
     "oas-schema-walker": "^1.0.3",
-    "oas-validator": "^1.1.1",
+    "oas-validator": "^1.1.7",
     "redoc": "next",
     "reftools": "^1.0.0",
     "should": "^13.2.0"

--- a/rules/default.json
+++ b/rules/default.json
@@ -38,9 +38,9 @@
         },
         {
             "name": "path-keys-no-trailing-slash",
-            "object": "pathInfo<--This doesnt exist so this whole rule is broke",
-            "enabled": false,
-            "description": "path item keys should not end with a slash",
+            "object": "paths",
+            "enabled": true,
+            "description": "paths should not end with a slash",
             "notEndWith": { "property": "$key", "value": "/" }
         },
         {


### PR DESCRIPTION
Updated our resolver with some changes to oas-linter (as hopefully one day they will merge). 

This specific change allows us to enable a rule that's been disabled for a while.