### PR TITLE
Fixed --skip option to linter

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -39,11 +39,11 @@ const createNewRule = rule => {
     activeRules[rule.name] = rule;
 }
 
-const relevantRules = skipRulesObject => {
+const relevantRules = (skipRulesObject) => {
     const rules = Object.values(activeRules);
-    const skipRules = Object.values(skipRulesObject);
+    const skipRules = Object.values(skipRulesObject || {});
 
-    if (!Array.isArray(skipRules)) return rules;
+    if (skipRules.length === 0) return rules;
 
     return rules.filter(rule => skipRules.indexOf(rule.name) === -1);
 }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -39,8 +39,9 @@ const createNewRule = rule => {
     activeRules[rule.name] = rule;
 }
 
-const relevantRules = skipRules => {
+const relevantRules = skipRulesObject => {
     const rules = Object.values(activeRules);
+    const skipRules = Object.values(skipRulesObject);
 
     if (!Array.isArray(skipRules)) return rules;
 


### PR DESCRIPTION
The `skipRules` variable is not an array, it's an object, just like `activeRules` causing `--skip` to not work.