### PR TITLE
AJV is no longer a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,14 +1968,14 @@
       "dev": true
     },
     "json-schema-ref-parser": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.2.tgz",
-      "integrity": "sha512-gP0mSqqkG99xNeA4F6bf2pXQYv5fFqe9SybbKO9qSMmyzzfFFIqd16s9Y65mRWKzZ0muTjyEtcSE/hLZLvIjZw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
+      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
       "requires": {
         "call-me-maybe": "^1.0.1",
         "debug": "^3.1.0",
         "js-yaml": "^3.12.0",
-        "ono": "^4.0.5"
+        "ono": "^4.0.6"
       }
     },
     "json-schema-to-openapi-schema": {
@@ -2426,7 +2426,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2748,8 +2747,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2833,7 +2831,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2880,8 +2877,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3147,8 +3143,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -3747,9 +3742,9 @@
       }
     },
     "polished": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-1.9.3.tgz",
-      "integrity": "sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.0.3.tgz",
+      "integrity": "sha512-MMwthxXsmZZlZY/x79KX/8kXpSU0lq3ntnDmAdhpQGk9pU9EM/rQmUbsgIuuk2Cvl6zYSWjyBsDEU8sa1598xg=="
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -3903,9 +3898,9 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-alpha.37.tgz",
-      "integrity": "sha512-yuT8sTT+oNzg8G9PfsUhu8Jhd9rWYJCTSQnbgaq9KzAFcJ2O0XfvlstkGXDK1zmtSSBBe5cy9Z/1XcQGDiGYug==",
+      "version": "2.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-alpha.38.tgz",
+      "integrity": "sha512-4pT/cRJ/aKdLlCxjFOSWvkA9ZVG5b9dUfxIM+H5698hlRaF6rcu4qh29eGwEikSDw0unH0iNd6MHy9u0fAjRGw==",
       "requires": {
         "classnames": "^2.2.6",
         "decko": "^1.2.0",
@@ -3920,15 +3915,15 @@
         "mobx-react": "^5.2.5",
         "openapi-sampler": "1.0.0-beta.14",
         "perfect-scrollbar": "^1.4.0",
-        "polished": "^1.9.3",
+        "polished": "^2.0.2",
         "prismjs": "^1.15.0",
         "prop-types": "^15.6.2",
-        "react-dropdown": "^1.6.1",
-        "react-hot-loader": "^4.3.4",
+        "react-dropdown": "^1.6.2",
+        "react-hot-loader": "^4.3.5",
         "react-tabs": "^2.0.0",
         "slugify": "^1.3.1",
         "stickyfill": "^1.1.1",
-        "styled-components": "^3.4.2",
+        "styled-components": "^3.4.5",
         "tslib": "^1.9.3"
       }
     },
@@ -4277,9 +4272,9 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "styled-components": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.4.tgz",
-      "integrity": "sha512-uOZbOmmB3LciaJCdwLb/1TavcFgI/usUK+NYK1YBhSSD/cheKZugqA7oi1/T5kQu/khBZXj2eaFdNaqREwTK8g==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.5.tgz",
+      "integrity": "sha512-/4c4/72+QAZ8LO+VIzTcitdjMcJleOln1laK9HZr166O+OmGpKZYt3+hRn0YhYPytwDGfx9J5c7WhU7Oys+nSw==",
       "requires": {
         "buffer": "^5.0.3",
         "css-to-react-native": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "url": "https://github.com/wework/speccy/issues"
   },
   "keywords": [
-    "swagger",
     "openapi",
     "openapi3",
+    "swagger",
     "documentation",
     "validator",
     "validation",
@@ -32,7 +32,6 @@
     "linter"
   ],
   "dependencies": {
-    "ajv": "^5.0.1",
     "commander": "^2.14.1",
     "ejs": "^2.5.2",
     "express": "^4.14.0",


### PR DESCRIPTION
Closes #139 

Now that we moved the resolver, validator, etc to oas-kit, we don't actually use ajv directly! 