### PR TITLE
Create Dockerfile and update README w/instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:latest
+RUN npm install --global speccy
+
+WORKDIR /project
+
+ENTRYPOINT ["speccy"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ loader
 
 If `options.resolve` is truthy, speccy will resolve _external_ references.
 
+### Using Docker
+
+Start by building the `Dockerfile` like:
+
+```
+docker build -t speccy:latest .
+```
+
+Then, simply run the speccy command you want to run like:
+
+```
+docker run speccy lint https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
+```
+
+You can work with local files by mounting your spec and any config files to the `/project` directory when you run the container:
+
+```
+docker run \
+  -v openapi.yaml:/project/openapi.yaml \
+  speccy lint openapi.yaml
+```
+
 ## Tests
 
 To run the test-suite:


### PR DESCRIPTION
- This creates a base Dockerfile to quickly work with speccy through docker.
- Also adds basic instructions to the README for usage in Docker

Addresses issue #155 