### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.2] - 2018-09-17
 ### Added
 - New rule for when the default rules match the example rules provided
 ### Fixed
 - `--skip` and `--rules` were being ignored in v0.8.0 - v0.8.1
+- Stopped `GET filename.yaml` showing up in normal output (should only show in verbose mode)
 
 ## [0.8.1] - 2018-08-22
 ### Fixed

--- a/docs/_includes/rules-list.html
+++ b/docs/_includes/rules-list.html
@@ -15,7 +15,7 @@
         {% if rule.object == "*" %}
         <em>everything</em>
         {% else %}
-        <a href="https://spec.openapis.org/oas/v3.0.0.html#{{ rule.object }}-object">{{ rule.object }}</a>
+        <a href="https://spec.openapis.org/oas/v3.0.1.html#{{ rule.object }}-object">{{ rule.object }}</a>
         {% endif %}
     </td>
     <td>{{ rule.description }}</td>

--- a/docs/_includes/rules-list.html
+++ b/docs/_includes/rules-list.html
@@ -14,10 +14,8 @@
     <td>
         {% if rule.object == "*" %}
         <em>everything</em>
-        {% elsif rule.object == "openapi" %}
-        <a href="https://swagger.io/specification/#oasObject">{{ rule.object }}</a>
         {% else %}
-        <a href="https://swagger.io/specification/#{{ rule.object }}Object">{{ rule.object }}</a>
+        <a href="https://spec.openapis.org/oas/v3.0.0.html#{{ rule.object }}-object">{{ rule.object }}</a>
         {% endif %}
     </td>
     <td>{{ rule.description }}</td>

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -142,6 +142,7 @@ const resolveContent = (openapi, options) => {
         externalRefs: {},
         rewriteRefs: true,
         openapi: openapi,
+        verbose: options.verbose === 2,
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.8.2-1",
+  "version": "0.8.2-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.8.2-2",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2414,7 +2414,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2736,8 +2735,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2821,7 +2819,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2868,8 +2865,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3135,8 +3131,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "linter"
   ],
   "dependencies": {
-    "commander": "^2.14.1",
+    "commander": "^2.18.0",
     "ejs": "^2.5.2",
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.8.2-2",
+  "version": "0.8.2",
   "description": "An OpenAPI v3 development workflow assistant",
   "homepage": "https://speccy.io/",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speccy",
-  "version": "0.8.2-1",
+  "version": "0.8.2-2",
   "description": "An OpenAPI v3 development workflow assistant",
   "homepage": "https://speccy.io/",
   "bin": {


### PR DESCRIPTION
### Added
- New rule for when the default rules match the example rules provided
### Fixed
- `--skip` and `--rules` were being ignored in v0.8.0 - v0.8.1
- Stopped `GET filename.yaml` showing up in normal output (should only show in verbose mode)