### PR TITLE
Small documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ docker run \
   speccy lint openapi.yaml
 ```
 
+### Using with lint-staged
+
+To lint your specifications before committing them you can use [lint-staged](https://github.com/okonet/lint-staged) to run speccy before each commit. Just install lint-staged and husky as `devDependencies` and add the following to your `package.json`:
+
+```
+"husky": {
+  "hooks": {  
+    "pre-commit": "lint-staged"
+  }
+},
+"lint-staged": {
+  "*.{yml, yaml}": ["speccy lint openapi.yml", "git add"]
+}
+```
+You can of course adjust the file filter and the speccy command to fit your setup.
+
 ## Tests
 
 To run the test-suite:

--- a/docs/_data/rules.yml
+++ b/docs/_data/rules.yml
@@ -69,6 +69,28 @@ default:
         - url: https://example.org/api/
       ```
 
+  - name: "path-keys-no-trailing-slash"
+    object: "paths"
+    description: "paths should not end with a slash"
+    more: |
+      A keys in the `paths` objects should not have a trailing slash, because `/` is actually the first
+      character of the path. Having it in both places will confuse some vendor tooling and you might see `//`
+      showing up in the full URL.
+
+      **Good**
+
+      ```
+      paths:
+        /pokemons/{pokemon_id}
+      ```
+
+      **Bad**
+
+      ```
+      paths:
+        /pokemons/{pokemon_id}/
+      ```
+
   - name:  "openapi-tags"
     object: "openapi"
     description: "openapi object should have non-empty tags array"

--- a/lint.js
+++ b/lint.js
@@ -57,7 +57,7 @@ const formatLintResults = lintResults => {
 ${colors.yellow + pointer} ${colors.cyan} R: ${rule.name} ${colors.white} D: ${rule.description}
 ${colors.reset + truncateLongMessages(error.message)}
 
-More information: https://speccy.io/rules/#${rule.name}
+More information: https://speccy.io/rules/1-rulesets#${rule.name}
 `;
     });
 


### PR DESCRIPTION
I picked up #61 and #133 as small additions to the documentation. To make the links in the `speccy lint` command work I needed to adjust the base URL of the docs. I'm not sure if that's correct.

Also I don't have experience with Ruby and jekyll but wanted to try to help with docs there. I seems to work when serving the docs locally so I hope it's done correctly.