### PR TITLE
Glob pattern for lint command

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,6 +6,11 @@ const path = require('path');
 const linter = require('./linter.js');
 const resolver = require('oas-resolver');
 const yaml = require('js-yaml');
+const isGlob = require('is-glob');
+const glob = require('glob');
+const util = require('util');
+
+const globAsync = util.promisify(glob);
 
 class ExtendableError extends Error {
     constructor(message) {
@@ -66,10 +71,17 @@ function readSpecFile(file, options) {
         return readFileAsync(file, 'utf8');
     }
 }
-
-const readOrError = async (file, options = {}) => {
+const readOrError = async (pattern, options = {}) => {
     try {
-        return await loadSpec(file, options);
+        if (isGlob(pattern)) {
+            const files = await globAsync(pattern);
+            return await Promise.all(
+                files.map((file) => loadSpec(file, options))
+            );
+        } else {
+            const spec = await loadSpec(pattern, options);
+            return [spec];
+        }
     }
     catch (error) {
         if (error instanceof OpenError) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,7 +6,6 @@ const path = require('path');
 const linter = require('./linter.js');
 const resolver = require('oas-resolver');
 const yaml = require('js-yaml');
-const isGlob = require('is-glob');
 const glob = require('glob');
 const util = require('util');
 
@@ -71,17 +70,17 @@ function readSpecFile(file, options) {
         return readFileAsync(file, 'utf8');
     }
 }
-const readOrError = async (pattern, options = {}) => {
+
+const readGlob = async (pattern, options = {}) => {
+    const files = await globAsync(pattern);
+    return await Promise.all(
+        files.map((file) => readOrError(file, options))
+    );
+}
+
+const readOrError = async (file, options = {}) => {
     try {
-        if (isGlob(pattern)) {
-            const files = await globAsync(pattern);
-            return await Promise.all(
-                files.map((file) => loadSpec(file, options))
-            );
-        } else {
-            const spec = await loadSpec(pattern, options);
-            return [spec];
-        }
+        return await loadSpec(file, options);
     }
     catch (error) {
         if (error instanceof OpenError) {
@@ -183,6 +182,7 @@ module.exports = {
     loadRuleFiles,
     loadSpec,
     readOrError,
+    readGlob,
     NetworkError,
     OpenError,
     ReadError,

--- a/lint.js
+++ b/lint.js
@@ -116,7 +116,7 @@ const command = async (filePattern, cmd) => {
         return 0;
     }).reduce((aggregator, curr) => aggregator + curr, 0);
 
-    process.exit(exitCode);
+    process.exit(exitCode !== 1 ? 1 : 0);
 };
 
 const buildLoaderOptions = (jsonSchema, verbose) => {

--- a/lint.js
+++ b/lint.js
@@ -116,7 +116,7 @@ const command = async (filePattern, cmd) => {
         return 0;
     }).reduce((aggregator, curr) => aggregator + curr, 0);
 
-    process.exit(exitCode !== 1 ? 1 : 0);
+    process.exit(exitCode !== 0 ? 1 : 0);
 };
 
 const buildLoaderOptions = (jsonSchema, verbose) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,8 +861,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -971,7 +970,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1126,8 +1124,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -1570,8 +1567,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1605,10 +1601,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1751,7 +1746,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1798,6 +1792,11 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1811,6 +1810,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-regex": {
       "version": "1.0.4",
@@ -2121,7 +2128,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2174,6 +2180,20 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "supports-color": {
           "version": "5.4.0",
@@ -3584,7 +3604,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3666,8 +3685,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -4400,8 +4418,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "commander": "^2.18.0",
     "ejs": "^2.5.2",
     "express": "^4.14.0",
+    "glob": "^7.1.3",
+    "is-glob": "^4.0.0",
     "js-yaml": "^3.6.1",
     "json-schema-to-openapi-schema": "^0.2.0",
     "nconf": "^0.10.0",


### PR DESCRIPTION
I tried to solve the problem posed in #118. It's now possible to lint multiple files with glob patterns supported by https://github.com/isaacs/node-glob. Additional to that I also pulled in https://github.com/micromatch/is-glob to check if the parameter the user supplied is a glob pattern or a filename.

This is my first PR which changes the actual code of the repo so I wanted to get it out as soon as possible to get your feedback and see if I'm on the right path. The globbing works and I tested it with a few example cases on my machine. Possible improvements would be more error handling if your glob pattern does for example return directories and probably more unit tests.

Please inform me if something important is missing or if should change the way it's implemented.