### PR TITLE
Improve docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:latest
+FROM node:11.1-stretch
 RUN npm install --global speccy
 
 WORKDIR /project
 
 ENTRYPOINT ["speccy"]
 CMD ["-h"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM node:11.1-stretch
-RUN npm install --global speccy
+FROM node:11.1-alpine
+
+RUN apk add --no-cache --virtual .build_deps git \
+    && npm install --global speccy \
+    && apk del .build_deps
 
 WORKDIR /project
 


### PR DESCRIPTION
This PR makes the `Dockerfile` a bit more explicit and also the resulting image smaller.

I'd also suggest you to configure Docker Hub to create builds based on tags too, which would help users to point to specific tags instead of `latest`.