### PR TITLE
Adding support for loading custom rulesets off the filesystem.

### DIFF
--- a/docs/rules/2-custom-rulesets.md
+++ b/docs/rules/2-custom-rulesets.md
@@ -64,7 +64,7 @@ There is a reserved `require` property (type `string`) at the top level, which c
 
 ### Using Custom Rulesets
 
-The `speccy lint` command supports `--rules`, and currently the value needs to be a URL to your custom ruleset file. Local file paths will not work. Pull requests welcome!
+The `speccy lint` command supports `--rules`, and the value can either be a URL to your custom ruleset file, or a path to a ruleset on your filesystem.
 
 <hr>
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -93,9 +93,13 @@ const recursivelyLoadRuleFiles = async (file, loadedFiles, options) => {
         if (verbose > 1) console.log('GET ' + file);
         data = await fetchUrl(file);
     }
+    else if (fs.existsSync(file)) {
+        if (verbose > 1) console.log('READ ' + file);
+        data = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+    }
     else {
         const ruleFile = path.join(__dirname, '../rules/' + file + '.json');
-        if (verbose > 1) console.log('GET ' + ruleFile);
+        if (verbose > 1) console.log('READ ' + ruleFile);
         data = yaml.safeLoad(fs.readFileSync(ruleFile, 'utf8'));
     }
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -17,10 +17,16 @@ describe('Loader', () => {
             loader.loadRuleFiles(['strict']).should.be.fulfilledWith(['strict', 'default']);
         });
 
-
         it('load default & strict rules', () => {
             loader.loadRuleFiles(['strict', 'default']).should.be.fulfilledWith(['strict', 'default']);
         });
+
+        context('when loading from a local file', () => {
+            it('retrieves rules from the file', () => {
+                const file = __dirname + '/../rules/strict.json'
+                loader.loadRuleFiles([file]).should.be.fulfilledWith([file, 'default']);
+            })
+        })
 
         context('when loading from url', () => {
             const host = 'http://example.org';


### PR DESCRIPTION
This adds support for being able to supply a custom ruleset on your filesystem to the `lint` command.

### Examples!

```
$ cat standards.json 
{
  "require": "strict",
  "rules": []
}

$ ./node_modules/.bin/speccy lint --verbose --rules=./standards.json docs/3.4/openapi/api.yaml 
READ ./standards.json
READ /Users/ursenbachj/code/vimeo-api/design/node_modules/speccy/rules/strict.json
READ /Users/ursenbachj/code/vimeo-api/design/node_modules/speccy/rules/default.json
Found 18 rules in default: parameter-description,parameter-name-regex,operation-operationId,operation-summary-or-description,operation-tags,path-keys-no-trailing-slash,server-trailing-slash,openapi-tags,openapi-tags-alphabetical,reference-no-other-properties,pathItem-summary-or-description,example-value-or-externalValue,default-and-example-are-redundant,reference-components-regex,no-script-tags-in-markdown,info-contact,license-apimatic-bug,no-eval-in-descriptions
Found 5 rules in strict: contact-properties,license-url,server-not-example.com,tag-description,short-summary
Found 0 rules in ./standards.json: 
GET docs/3.4/openapi/api.yaml
Specification contains lint errors: 596

#/info/contact  R: contact-properties  D: contact object should have name, url and email
expected Object { url: 'https://developer.vimeo.com/help' } to have property name

More information: https://speccy.io/rules/#contact-properties

...
```

`standards.json` is loaded off my filesystem, which then requires the stock `strict` rule, which then also requires `default`. 

Supplying a ruleset name, like `strict`, still works as well:

```
$ ./node_modules/.bin/speccy lint --verbose --rules=strict docs/3.4/openapi/api.yaml 
READ /Users/ursenbachj/code/vimeo-api/design/node_modules/speccy/rules/strict.json
READ /Users/ursenbachj/code/vimeo-api/design/node_modules/speccy/rules/default.json
Found 18 rules in default: parameter-description,parameter-name-regex,operation-operationId,operation-summary-or-description,operation-tags,path-keys-no-trailing-slash,server-trailing-slash,openapi-tags,openapi-tags-alphabetical,reference-no-other-properties,pathItem-summary-or-description,example-value-or-externalValue,default-and-example-are-redundant,reference-components-regex,no-script-tags-in-markdown,info-contact,license-apimatic-bug,no-eval-in-descriptions
Found 5 rules in strict: contact-properties,license-url,server-not-example.com,tag-description,short-summary
GET docs/3.4/openapi/api.yaml
Specification contains lint errors: 596

#/info/contact  R: contact-properties  D: contact object should have name, url and email
expected Object { url: 'https://developer.vimeo.com/help' } to have property name

More information: https://speccy.io/rules/#contact-properties

...
```