### PR TITLE
Adding support for pattern matching to `notContain` rulesets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `notContain` rulesets can now support pattern matching. ([#208] via [@erunion])
+
+[@erunion]: https://github.com/erunion
+[#208]: https://github.com/wework/speccy/issues/208
+
 ## [0.8.5] - 2018-11-15
 ### Added
 - Custom rulesets can now be loaded from the local filesystem, thanks [@erunion]! ([#196])

--- a/docs/rules/2-custom-rulesets.md
+++ b/docs/rules/2-custom-rulesets.md
@@ -52,7 +52,7 @@ There is a reserved `require` property (type `string`) at the top level, which c
 |alphabetical|object|reserved|Makes sure values are in alphabetical order. Structure: `{ properties: string, keyedBy: string }`|
 |or|array|no|An array of property names, one or more of which must be present|
 |maxLength|object|reserved|An object containing a `property` string name, and a `value` (integer). The length of the `property` value must not be longer than `value`|
-|notContain|object|no|An object containing a `properties` array and a `value`. None of the `properties` must contain the `value`. Used with strings|
+|notContain|object|no|An object containing a `properties` array and either a `value` (case-sensitive string matches) or `pattern` (full regex matching). If using `value`, none of the `properties` must contain the `value`. If using `pattern`, you should supply `pattern.value` which contains your regex. If you wish to also supply additional flags, you can do so on `pattern.flags`.|
 |notEndWith|object|no|An object containing a `property`, an optional `omit` prefix and a `value` string. The given `property` (once `omit` is removed) must not end with the given `value`. Used with strings|
 |notEquals|object|no|An array containing a list of property names, which must have different values if present|
 |pattern|object|no|An object containing a `property` name, an optional `split` string which is used to split the value being tested into individual components, an optional `omit` string (which is chopped off the front of each component being tested), and a `value` regex property which is used to test all components of the property value being tested|

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -173,11 +173,19 @@ const lint = (objectName, object, key, options = {}) => {
                 }
             }
             if (rule.notContain) {
-                const { value, properties } = rule.notContain;
+                const { value, pattern, properties } = rule.notContain;
                 for (const property of properties) {
                     if (object[property]) {
+                        let match
+                        if (typeof value !== 'undefined') {
+                            match = regexFromString(value)
+                        } else {
+                            let flags = (typeof pattern.flags !== 'undefined') ? pattern.flags : ''
+                            match = new RegExp(pattern.value, flags)
+                        }
+
                         ensure(rule, () => {
-                            object[property].should.be.a.String().and.not.match(regexFromString(value), rule.description);
+                            object[property].should.be.a.String().and.not.match(match, rule.description);
                         });
                     }
                 }

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -136,6 +136,61 @@ describe('Linter', () => {
                 });
             });
 
+            context("notContain", () => {
+                context('when linting with a string', () => {
+                    const rule = {
+                        "name": "doesnt-contain-foo",
+                        "object": "*",
+                        "enabled": true,
+                        "notContain": { "properties": ["description"], "value": "foo" }
+                    }
+
+                    it('accepts a value when foo is not present', () => {
+                        lintAndExpectValid(rule, {"description": "bar"});
+                    });
+
+                    it('errors when foo is present', () => {
+                        lintAndExpectErrors(rule, {"description": "foo"}, ['doesnt-contain-foo']);
+                        lintAndExpectErrors(rule, {"description": "foobar"}, ['doesnt-contain-foo']);
+                    });
+                });
+
+                context('when linting with regex', () => {
+                    let rule = {
+                        "name": "doesnt-contain-foo",
+                        "object": "*",
+                        "enabled": true,
+                        "notContain": {
+                            "properties": ["description"],
+                            "pattern": {
+                                "value": "[f|F]oo"
+                            }
+                        }
+                    }
+
+                    it('accepts a value when foo is not present', () => {
+                        lintAndExpectValid(rule, {"description": "bar"});
+                    });
+
+                    it('errors when foo is present', () => {
+                        lintAndExpectErrors(rule, {"description": "foobar"}, ['doesnt-contain-foo']);
+                    });
+
+                    context('when supplying additional regex flags', () => {
+                        rule.notContain.pattern.value = 'foo'
+                        rule.notContain.pattern.flags = 'gi'
+
+                        it('accepts a value when foo is not present', () => {
+                            lintAndExpectValid(rule, {"description": "bar"});
+                        });
+
+                        it('errors when foo is present', () => {
+                            lintAndExpectErrors(rule, {"description": "fOoBaR"}, ['doesnt-contain-foo']);
+                        });
+                    })
+                })
+            });
+
             context('notEndWith', () => {
                 context('when property is $key', () => {
                     const rule = {


### PR DESCRIPTION
This opens up the `notContain` ruleset to support pattern matching.

Real world example:

* Internally at Vimeo we refer to a video as a "clip". Externally, they should be referred to in our API documentation as a "video". With the normal `notContain`, we could only assert that "clip" didn't appear, and aside from creating a separate rule, we couldn't also assert that "Clip" didn't appear.