### PR TITLE
Added rule hasKey

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -200,10 +200,9 @@ const lint = (objectName, object, key, options = {}) => {
                         if (res !== null) found= true;
                     }
                 };
-                         
                 ensure(rule, () => {
                     found.should.be.exactly(true, rule.description);
-                });                    
+                });                  
             }
             if (rule.notEndWith) {
                 const { omit, property, value } = rule.notEndWith;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -190,6 +190,21 @@ const lint = (objectName, object, key, options = {}) => {
                     }
                 }
             }
+            if (rule.hasKey) {
+                let found = false;
+                let elements = Object.keys(object);
+                for (const val of rule.hasKey){
+                    let regExQuery = new RegExp(val,'i');
+                    for(const elem of elements){
+                        let res = elem.match(regExQuery);
+                        if (res !== null) found= true;
+                    }
+                };
+                         
+                ensure(rule, () => {
+                    found.should.be.exactly(true, rule.description);
+                });                    
+            }
             if (rule.notEndWith) {
                 const { omit, property, value } = rule.notEndWith;
                 let propertyValue = (property === '$key') ? key : object[property];


### PR DESCRIPTION
Added the rule hasKey to verify that the Paths object has ONE pathItem which contains one of the values provided in the rule.

Sample Rule:
            "name": "health-check",
            "object": "paths",
            "enabled": true,
            "description": "An health endpoint is required",
            "hasKey":  ["health", "status"]

So a pathItem with "/dssdhealth" will pass ...