### PR TITLE
Allow pattern matching on key

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -151,7 +151,7 @@ const lint = (objectName, object, key, options = {}) => {
             }
             if (rule.pattern) {
                 const { omit, property, split, value } = rule.pattern;
-                const target = object[property]
+                const target = (property === '$key') ? key : object[property];
 
                 let components = [];
                 if (target) {


### PR DESCRIPTION
This PR makes it possible to create rules that does pattern matching on the key of an object.

For example, for the key of a path you can create the following rule:

>        {
>            "name":"path-item-lowercased-hyphens",
>            "object": "paths",
>            "enabled": true,
>            "description": "path items must be lowercase and separated with hyphens",
>            "pattern": { "property": "$key", "split": "/", "value": "^{[^}]*}$|^([a-z-\/]*)$" }
>        }

This relates to #214 