### PR TITLE
Only report to coveralls if not a fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,21 @@
 version: 2
+commands:
+    # Command based on instructions from CircleCI blog for avoiding fork secret leakage or failures
+    # https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/
+    coverage:
+        description: >-
+            Report coverage, and send to Coveralls if its not a fork.
+        steps:
+            - run:
+                name: Coverage
+                command: |
+                    if [ -n "$CIRCLE_PR_NUMBER" ]; then
+                        npm run coverage
+                    else
+                        npm run coverage | coveralls
+                    fi
+
 shared: &shared
-    docker:
-        - image: circleci/node:latest
     steps:
         - checkout
         - restore_cache:
@@ -19,22 +33,22 @@ shared: &shared
         - run:
             name: Tests
             command: npm test
-        - run:
-           name: Report Coverage
-           command: npm run coverage
+        - coverage
 
 jobs:
     node-latest:
+        docker:
+            - image: circleci/node:latest
+        <<: *shared
+
+    node-11:
+        docker:
+            - image: circleci/node:11
         <<: *shared
 
     node-10:
         docker:
             - image: circleci/node:10
-        <<: *shared
-
-    node-9:
-        docker:
-            - image: circleci/node:9
         <<: *shared
 
     node-8:
@@ -65,8 +79,8 @@ workflows:
     commit:
         jobs:
             - node-latest
+            - node-11
             - node-10
-            - node-9
             - node-8
             - build-image
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 commands:
     # Command based on instructions from CircleCI blog for avoiding fork secret leakage or failures
     # https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/
@@ -15,55 +16,59 @@ commands:
                         npm run coverage | coveralls
                     fi
 
-shared: &shared
-    steps:
-        - checkout
-        - restore_cache:
-            key: dependency-cache-{{ checksum "package.json" }}
-        - run:
-            name: Update npm
-            command: 'sudo npm install -g npm@latest'
-        - run:
-            name: Install npm dependencies
-            command: npm install
-        - save_cache:
-            key: dependency-cache-{{ checksum "package.json" }}
-            paths:
-              - node_modules
-        - run:
-            name: Tests
-            command: npm test
-        - coverage
+    install-and-test:
+        description: >-
+            Install everything required to run the test suite, then run it.
+        steps:
+            - checkout
+            - restore_cache:
+                key: dependency-cache-{{ checksum "package.json" }}
+            - run:
+                name: Update npm
+                command: 'sudo npm install -g npm@latest'
+            - run:
+                name: Install npm dependencies
+                command: npm install
+            - save_cache:
+                key: dependency-cache-{{ checksum "package.json" }}
+                paths:
+                    - node_modules
+            - run: npm test
+            - coverage
 
 jobs:
     node-latest:
         docker:
             - image: circleci/node:latest
-        <<: *shared
+        steps:
+            - install-and-test
 
     node-11:
         docker:
             - image: circleci/node:11
-        <<: *shared
+        steps:
+            - install-and-test
 
     node-10:
         docker:
             - image: circleci/node:10
-        <<: *shared
+        steps:
+            - install-and-test
 
     node-8:
         docker:
             - image: circleci/node:8
-        <<: *shared
+        steps:
+            - install-and-test
 
-    build-image:
+    build-docker:
         machine: true
         steps:
             - checkout
             - run: docker run --rm -i hadolint/hadolint < Dockerfile
             - run: docker build -t speccy:$CIRCLE_SHA1 .
 
-    push-image:
+    push-docker:
         machine: true
         steps:
             - checkout
@@ -82,11 +87,11 @@ workflows:
             - node-11
             - node-10
             - node-8
-            - build-image
+            - build-docker
 
     deploy:
         jobs:
-            - push-image:
+            - push-docker:
                 filters:
                     branches:
                         only: master

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "nyc --reporter=html --reporter=text mocha",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov"
   },
   "preferGlobal": true,
   "repository": {


### PR DESCRIPTION
Fixes #241 - Since we started pushing to docker, we disabled secrets being passed to forks. This lead to coveralls failing, so this PR skips trying to push to coveralls unless its on _this_ repo (not forks). The specific ENV var for that looks a bit funny, but the advice is taken from [the CircleCI blog](https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/).

I am also sending from a personal fork to prove this change actually works for forks. Which it does! Whooop.