### PR TITLE
Fix openapi-tags-alphabetical rule invalid property declaration

### DIFF
--- a/rules/default.yaml
+++ b/rules/default.yaml
@@ -45,7 +45,8 @@ rules:
   object: openapi
   description: openapi object should have alphabetical tags
   alphabetical:
-    properties: tags
+    properties:
+      - tags
     keyedBy: name
 - name: reference-no-other-properties
   object: reference


### PR DESCRIPTION
Since version 0.9.0 the `openapi-tags-alphabetical` rule is not working due to a invalid type of its `properties` attribute ([Reference](https://github.com/wework/speccy/blob/85efdbd84f150d41271df014ea8741583babbb7b/rules/default.yaml#L48)). It must be an array of strings instead of a string. Like this:

```yaml
- name: openapi-tags-alphabetical
  object: openapi
  description: openapi object should have alphabetical tags
  alphabetical:
    properties:
      - tags
    keyedBy: name
```

The reason that it stopped working is that in the 0.8.x version from the speecy side there was an [adaptation](https://github.com/wework/speccy/blob/b999fa5a5524fc90efe6d9f6f3aed8ab6b4a0f98/lib/linter.js#L35-L37) done while the rule was being created.
As on version 0.9.x it relies on oas-linter this code was removed and delegates it to that module, but this adaptation is not present [here](https://github.com/Mermade/oas-kit/blob/1beefadc325de7c7d0f1cfb380b6015775fe94cf/packages/oas-linter/index.js#L25-L29).

Maybe it is better to add the adaptation and/or a data type validation in oas-linter rules to avoid silent fails (The rule result was always ok because it tried to find in the openapi spec a property whose name was the first letter of the configured property in the rule due to [this `for`](https://github.com/Mermade/oas-kit/blob/1beefadc325de7c7d0f1cfb380b6015775fe94cf/packages/oas-linter/index.js#L101)).
Let me know if you agree on adding the adaptation in oas-linter, I could open a PR in that case.