### PR TITLE
Fix overriding a rule with a disable one

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -14,12 +14,15 @@ const createNewRules = (rules, rulesetDocumentationUrl) => {
 };
 
 const createNewRule = (rule, rulesetDocumentationUrl) => {
-    if (rule.disabled === true) {
-        delete activeRules[rule.name];
-        return;
-    }
     // @DEPRECATED in v0.9.0, use `disabled: true`
-    if (rule.enabled === false) {
+    if (rule.enabled !== undefined) {
+        console.warn("WARNING: Property 'enabled' is deprecated and will be removed in 1.0.0. Use 'disabled' instead. Found in rule: " + rule.name)
+    }
+    if (rule.enabled === false && rule.disabled === undefined) {
+        rule.disabled = true;
+    }
+
+    if (rule.disabled === true) {
         delete activeRules[rule.name];
         return;
     }

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -14,25 +14,31 @@ const createNewRules = (rules, rulesetDocumentationUrl) => {
 };
 
 const createNewRule = (rule, rulesetDocumentationUrl) => {
-    if (rule.disabled === true) return;
+    if (rule.disabled === true) {
+        delete activeRules[rule.name];
+        return;
+    }
     // @DEPRECATED in v0.9.0, use `disabled: true`
-    if (rule.enabled === false) return;
+    if (rule.enabled === false) {
+        delete activeRules[rule.name];
+        return;
+    }
 
     if (!rule.url) rule.url = (rulesetDocumentationUrl) ? rulesetDocumentationUrl : documentationUrl;
 
     activeRules[rule.name] = rule;
-}
+};
 
 const getRules = () => {
     return {
         "rules": relevantRules(Object.values(activeRules), skipRules)
     };
-}
+};
 
 const relevantRules = (rulesList, skipList) => {
     if (skipList.length === 0) return rulesList;
     return rulesList.filter(rule => skipList.indexOf(rule.name) === -1);
-}
+};
 
 module.exports = {
     createNewRule,

--- a/test/lib/rules.test.js
+++ b/test/lib/rules.test.js
@@ -39,6 +39,16 @@ describe('Rules', () => {
                 expect(rules.getRules().rules[0].url).toBe('http://test');
             });
 
+            test('deletes a previously added rule if the overriding rule is disabled', () => {
+                rules.init();
+
+                rules.createNewRule(activeRule);
+                expect(rules.getRules().rules).toHaveLength(1);
+
+                // inheriting a rule with the same name but disabled
+                rules.createNewRule(Object.assign({}, activeRule, {disabled: true}));
+                expect(rules.getRules().rules).toHaveLength(0);
+            });
         });
 
         describe('when skipping rules', () => {


### PR DESCRIPTION
If we want to disable a rule from an inherited set of rules through overriding it in the child ruleset (*) the disabled rule is not created but the rule from the parent is left on the set of active rules.

Example:

```yaml
require: default
rules:
    - name: openapi-tags-alphabetical
      disabled: true
```
(`openapi-tags-alphabetical` is defined in `default`)

This fix this situation by deleting the rule (if exists) from the set of active rules if the most specific rule is declared as disabled.

I took the liberty to add a deprecation message with an estimated version in which the `enabled` property would be removed. I can revert it if you think that it is not necessary.

The lines range 16-22 should be removed when `enabled` is deleted.

**(*):** Another option would be using `skip` but I think this option more like a temporal option used under some situation while you develop. Having it disabled in the ruleset is more organized (and, for example, you can leave a comment why you are disabling it).