### PR TITLE
Config: prevent meaningless empty arrays override options in file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,8 +15,8 @@ class Config {
             verbose: args.verbose,
             // Command specific options
             lint: {
-                rules: args.rules,
-                skip: args.skip,
+                rules: this.notEmptyArray(args.rules),
+                skip: this.notEmptyArray(args.skip),
             },
             resolve: {
                 output: args.output,
@@ -70,6 +70,17 @@ class Config {
             }
         });
         return cleaned;
+    }
+
+    /**
+     * Check and returns the given array if it is not empty. Otherwise it returns 'undefined'.
+     * Useful for configuration options where an empty array has no meaning.
+     *
+     * @param array The array instance to check.
+     * @returns {array|undefined} The given array; or 'undefined' if array is 'undefined' or empty.
+     */
+    notEmptyArray(array) {
+        return array && array.length > 0 ? array : undefined;
     }
 }
 

--- a/lint.js
+++ b/lint.js
@@ -69,8 +69,8 @@ const command = async (specFile, cmd) => {
     config.init(cmd);
     const jsonSchema = config.get('jsonSchema');
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
-    const rulesets = config.get('lint:rules');
-    const skip = config.get('lint:skip');
+    const rulesets = config.get('lint:rules', []);
+    const skip = config.get('lint:skip', []);
 
     rules.init({
         skip

--- a/test/integration/lint.test.js
+++ b/test/integration/lint.test.js
@@ -6,6 +6,7 @@ const lint = require('../../lint.js');
 
 const commandConfig = {
     quiet: false,
+    verbose: false,
     rules: [],
     skip: []
 };

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -38,6 +38,20 @@ describe('Config', () => {
                     'https://example.org/my-rules.json',
                 ]);
             });
+
+            test('meaningless empty arrays in default config must not override options of config file', () => {
+                config.init({parent: {config: configFile, rules: [], skip: []}});
+
+                expect(config.get('lint:rules')).toEqual([
+                    'strict',
+                    './some/local/rules.json',
+                    'https://example.org/my-rules.json',
+                ]);
+
+                expect(config.get('lint:skip')).toEqual([
+                    'info-contact',
+                ]);
+            });
         });
     });
 


### PR DESCRIPTION
It fixes the impossibility that the `rules` and `skip` options specified in `speccy.yaml` config file are used when these options are not override from command line.

The `Commander.js` configuration has an empty array as a default/initial value for `rules` and `skip`. If you execute the `lint` command from the command line without specifying those arguments, when the config is loaded those 'supplied' literal config values (empty arrays) overrides the ones defined in a `speccy.yaml` file (because they are not `undefined`).

There is a test validating the config hierarchy but, as the configuration passed to `init()` is handcrafted, it wasn't simulating the output of `Commander.js` read options.
Now, a test simulating this case was added.