### PR TITLE
fix regression in displaying assertion errors

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -25,8 +25,8 @@ const formatSchemaError = (err, context) => {
     let output = `
 ${colors.yellow + pointer}
 `;
-
-    if (err.name === 'AssertionError') {
+    
+    if (err.name === 'AssertionError' || err.error.name === 'AssertionError') {
         output += colors.reset + truncateLongMessages(err.message);
     }
     else if (err instanceof validator.CLIError) {
@@ -89,7 +89,13 @@ const command = async (specFile, cmd) => {
 
             if (err && valid === false) {
                 console.error(colors.red + 'Specification schema is invalid.' + colors.reset);
-                console.error(formatSchemaError(err, context));
+                if (err.name === 'AssertionError') {
+                    console.error(formatSchemaError(err, context));
+                }
+
+                for (let linterResult of err.options.linterResults()) {
+                    console.error(formatSchemaError(linterResult, context));
+                }
                 return reject();
             }
 


### PR DESCRIPTION
Fixes the issues mentioned in #335 

Seems to be some regression in how the different elements interact with each other. This is a quick fix to solve the regression, but we need to properly fix the error handling.