### PR TITLE
Introduce checkstyle and JUnit output formats for lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Options:
   -s, --skip [ruleName]     provide multiple rules to skip
   -j, --json-schema         treat $ref like JSON Schema and convert to OpenAPI Schema Objects
   -o, --output [format]     output as [format], supports: console, checkstyle, junit (default: console)
-  -f, --output-file [file]  path to write the output to (optional)
+  -f, --output-file [file]  path to write the output to (optional). This option is only applicable to output type checkstyle or junit
   -v, --verbose             set verbosity (use multiple times to increase level)
   -h, --help                output usage information
 ```

--- a/README.md
+++ b/README.md
@@ -61,12 +61,14 @@ ensure specs are not just valid OpenAPI, but lint against specified rules
 
 Options:
 
-  -q, --quiet             reduce verbosity
-  -r, --rules [ruleFile]  provide multiple rules files
-  -s, --skip [ruleName]   provide multiple rules to skip
-  -j, --json-schema       treat $ref like JSON Schema and convert to OpenAPI Schema Objects
-  -v, --verbose           set verbosity (use multiple times to increase level)
-  -h, --help              output usage information
+  -q, --quiet               reduce verbosity
+  -r, --rules [ruleFile]    provide multiple rules files
+  -s, --skip [ruleName]     provide multiple rules to skip
+  -j, --json-schema         treat $ref like JSON Schema and convert to OpenAPI Schema Objects
+  -o, --output [format]     output as [format], supports: console, checkstyle, junit (default: console)
+  -f, --output-file [file]  path to write the output to (optional)
+  -v, --verbose             set verbosity (use multiple times to increase level)
+  -h, --help                output usage information
 ```
 
 You'll see output such as:

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,8 @@ class Config {
             lint: {
                 rules: this.notEmptyArray(args.rules),
                 skip: this.notEmptyArray(args.skip),
-                output: args.output
+                output: args.output,
+                outputFile: args.outputFile
             },
             resolve: {
                 output: args.output,

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ class Config {
             lint: {
                 rules: this.notEmptyArray(args.rules),
                 skip: this.notEmptyArray(args.skip),
+                output: args.output
             },
             resolve: {
                 output: args.output,

--- a/lib/output/checkstyle.js
+++ b/lib/output/checkstyle.js
@@ -17,7 +17,7 @@ const render = (error, warnings, valid, context, quiet) => {
     xmlContent += '</file>\n';
     xmlContent += '</checkstyle>\n';
 
-    console.log(xmlContent);
+    return xmlContent;
 };
 
 module.exports = {

--- a/lib/output/checkstyle.js
+++ b/lib/output/checkstyle.js
@@ -1,0 +1,25 @@
+const renderIssue = validation => {
+    return `<error line="0" severity="error" message="${validation.message}" source="${validation.ruleName}" />\n`;
+};
+
+const render = (error, warnings, valid, context, quiet) => {
+    let xmlContent = '<xml version="1.0" encoding="utf-8"?>\n';
+    xmlContent += '<checkstyle version="1.0">\n';
+    xmlContent += `<file name="${error.options.openapi.info.title}">\n`;
+
+    const results = error.options.linterResults();
+
+    for (let i = 0; i < results.length; i++) 
+    {
+        xmlContent += renderIssue(results[i]);
+    }
+
+    xmlContent += '</file>\n';
+    xmlContent += '</checkstyle>\n';
+
+    console.log(xmlContent);
+};
+
+module.exports = {
+    render: render
+};

--- a/lib/output/console.js
+++ b/lib/output/console.js
@@ -1,0 +1,83 @@
+const colors = process.env.NODE_DISABLE_COLORS ? {} : {
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    blue: '\x1b[34m',
+    magenta: '\x1b[35m',
+    cyan: '\x1b[36m',
+    white: '\x1b[37m',
+    reset: '\x1b[0m'
+};
+
+const formatSchemaError = (err, context) => {
+    const pointer = context.pop();
+    let output = `
+${colors.yellow + pointer}
+`;
+    
+    if (err.name === 'AssertionError' || err.error.name === 'AssertionError') {
+        output += colors.reset + truncateLongMessages(err.message);
+    }
+    else if (err instanceof validator.CLIError) {
+        output += colors.reset + err.message;
+    }
+    else {
+        output += colors.red + err.stack;
+    }
+    return output;
+}
+
+const truncateLongMessages = message => {
+    let lines = message.split('\n');
+    if (lines.length > 6) {
+        lines = lines.slice(0, 5).concat(
+            ['  ... snip ...'],
+            lines.slice(-1)
+        );
+    }
+    return lines.join('\n');
+}
+
+const formatLintResults = lintResults => {
+    let output = '';
+    lintResults.forEach(result => {
+        const { rule, error, pointer } = result;
+
+        output += `
+${colors.yellow + pointer} ${colors.cyan} R: ${rule.name} ${colors.white} D: ${rule.description}
+${colors.reset + truncateLongMessages(error.message)}
+
+More information: ${rule.url}#${rule.name}
+`;
+    });
+
+    return output;
+}
+
+const render = (error, warnings, valid, context, quiet) => {
+    if (error && valid === false) {
+        console.error(colors.red + 'Specification schema is invalid.' + colors.reset);
+        if (error.name === 'AssertionError') {
+            console.error(formatSchemaError(error, context));
+        }
+    
+        for (let linterResult of error.options.linterResults()) {
+            console.error(formatSchemaError(linterResult, context));
+        };
+    }
+
+    if (warnings.length) {
+        console.error(colors.red + 'Specification contains lint errors: ' + warnings.length + colors.reset);
+        console.warn(formatLintResults(warnings))
+    }
+
+    if(!error && warnings.length === 0) {
+        if (!quiet) {
+            console.log(colors.green + 'Specification is valid, with 0 lint errors' + colors.reset);
+        }
+    }
+}
+
+module.exports = {
+    render: render
+ };

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -45,7 +45,7 @@ const render = (error, warnings, valid, context, quiet) => {
     
     xmlContent += '</testsuites>\n';
 
-    console.log(xmlContent);
+    return xmlContent;
 };
 
 module.exports = {

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -1,17 +1,24 @@
 const renderIssue = validation => {
-    let content = `<testcase name="${validation.name}" classname="${validation.className}" assertions="1">\n`;
-    content += `    <failure message="${validation.ruleDescription}"><![CDATA[${validation.message}]]></failure>\n`;
-    content += '</testcase>\n';
+    let content = `\t\t<testcase name="${validation.ruleDescription}" classname="${validation.className}" assertions="1">\n`;
+    content += `\t\t\t<failure message="${validation.ruleDescription}"></failure>\n`;
+    content += '\t\t</testcase>\n';
 
     return content;
 };
 
-const render = (error, warnings, valid, context, quiet) => {
+const getNicePointerOf = (validation) => {
+    let x = validation.pointer.replace('#/paths/', '');
+    let pos = x.indexOf('/');
+    return x.substring(0, pos).split('~1').join('/')
+}
+const render = (error, warnings, valid, context, quiet, numberOfRules) => {
     const results = error.options.linterResults();
     let testSuites = [];
 
     results.forEach(validation => {
-        const testSuiteName = validation.rule.url;
+        validation.nicePointer = getNicePointerOf(validation);
+        
+        const testSuiteName = validation.nicePointer;
 
         if(testSuites[testSuiteName] === undefined) {
             testSuites[testSuiteName] = {
@@ -34,13 +41,13 @@ const render = (error, warnings, valid, context, quiet) => {
     Object.keys(testSuites).forEach(key => {
         let testSuite = testSuites[key];
         
-        xmlContent += `<testsuite name="${testSuite.name}" tests="${results.length}" failures="${results.length}">\n`;
+        xmlContent += `\t<testsuite name="${testSuite.name}" tests="${numberOfRules}" failures="${testSuite.testCases.length}">\n`;
 
         testSuite.testCases.forEach(function(testCase) {
             xmlContent += renderIssue(testCase);
         });
         
-        xmlContent += '</testsuite>\n';
+        xmlContent += '\t</testsuite>\n';
     });
     
     xmlContent += '</testsuites>\n';

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -28,7 +28,7 @@ const render = (error, warnings, valid, context, quiet) => {
         });
     });
 
-    let xmlContent = '<xml version="1.0" encoding="utf-8"?>\n';
+    let xmlContent = '<?xml version="1.0" encoding="utf-8"?>\n';
     xmlContent += `<testsuites>\n`;
 
     Object.keys(testSuites).forEach(key => {

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -6,18 +6,21 @@ const renderIssue = validation => {
     return content;
 };
 
-const getNicePointerOf = (validation) => {
-    let x = validation.pointer.replace('#/paths/', '');
-    let pos = x.indexOf('/');
-    return x.substring(0, pos).split('~1').join('/')
-}
 const render = (error, warnings, valid, context, quiet, numberOfRules) => {
     const results = error.options.linterResults();
     let testSuites = [];
 
     results.forEach(validation => {
-        validation.nicePointer = getNicePointerOf(validation);
+        let x = validation.pointer.replace('#/paths/', '');
+        let pos = x.indexOf('/');
+        let method = x.substring(pos+1);
+        if(method.indexOf('/') > 0) {
+            method = method.substring(0, method.indexOf('/'));
+        }
         
+        validation.method = method;
+        validation.nicePointer = method.toUpperCase() + ' ' + x.substring(0, pos).split('~1').join('/');
+
         const testSuiteName = validation.nicePointer;
 
         if(testSuites[testSuiteName] === undefined) {

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -1,6 +1,6 @@
 const renderIssue = validation => {
     let content = `\t\t<testcase name="${validation.ruleDescription}" classname="${validation.className}" assertions="1">\n`;
-    content += `\t\t\t<failure message="${validation.ruleDescription}"></failure>\n`;
+    content += `\t\t\t<failure message="${validation.ruleDescription}"><![CDATA[${validation.message}]]></failure>\n`;
     content += '\t\t</testcase>\n';
 
     return content;
@@ -32,7 +32,7 @@ const render = (error, warnings, valid, context, quiet, numberOfRules) => {
 
         testSuites[testSuiteName].testCases.push({
             name: validation.rule.name,
-            className: validation.pointer.substring(8).replace(/~1/g, "/"),
+            className: validation.nicePointer,
             message: validation.message,
             ruleDescription: validation.rule.description
         });

--- a/lib/output/junit.js
+++ b/lib/output/junit.js
@@ -1,0 +1,53 @@
+const renderIssue = validation => {
+    let content = `<testcase name="${validation.name}" classname="${validation.className}" assertions="1">\n`;
+    content += `    <failure message="${validation.ruleDescription}"><![CDATA[${validation.message}]]></failure>\n`;
+    content += '</testcase>\n';
+
+    return content;
+};
+
+const render = (error, warnings, valid, context, quiet) => {
+    const results = error.options.linterResults();
+    let testSuites = [];
+
+    results.forEach(validation => {
+        const testSuiteName = validation.rule.url;
+
+        if(testSuites[testSuiteName] === undefined) {
+            testSuites[testSuiteName] = {
+                name: testSuiteName,
+                testCases: []
+            };
+        }
+
+        testSuites[testSuiteName].testCases.push({
+            name: validation.rule.name,
+            className: validation.pointer.substring(8).replace(/~1/g, "/"),
+            message: validation.message,
+            ruleDescription: validation.rule.description
+        });
+    });
+
+    let xmlContent = '<xml version="1.0" encoding="utf-8"?>\n';
+    xmlContent += `<testsuites>\n`;
+
+    Object.keys(testSuites).forEach(key => {
+        let testSuite = testSuites[key];
+        
+        xmlContent += `<testsuite name="${testSuite.name}" tests="${results.length}" failures="${results.length}">\n`;
+
+        testSuite.testCases.forEach(function(testCase) {
+            xmlContent += renderIssue(testCase);
+        });
+        
+        xmlContent += '</testsuite>\n';
+    });
+    
+    xmlContent += '</testsuites>\n';
+
+    console.log(xmlContent);
+};
+
+module.exports = {
+    render: render
+};

--- a/lib/output/toFileRenderer.js
+++ b/lib/output/toFileRenderer.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 
 const outputToFileRenderer = (renderer, outputFileName) => {
     return {
-        render: (error, warnings, valid, context, quiet) => {
-            const output = renderer.render(error, warnings, valid, context, quiet);
+        render: (error, warnings, valid, context, quiet, numberOfRules) => {
+            const output = renderer.render(error, warnings, valid, context, quiet, numberOfRules);
 
             fs.writeFileSync(
                 outputFileName, 

--- a/lib/output/toFileRenderer.js
+++ b/lib/output/toFileRenderer.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+const outputToFileRenderer = (renderer, outputFileName) => {
+    return {
+        render: (error, warnings, valid, context, quiet) => {
+            const output = renderer.render(error, warnings, valid, context, quiet);
+
+            fs.writeFileSync(
+                outputFileName, 
+                output);
+        }
+    };
+}
+
+module.exports = {
+    outputToFileRenderer: outputToFileRenderer
+};

--- a/lint.js
+++ b/lint.js
@@ -11,13 +11,19 @@ const fromJsonSchema = require('json-schema-to-openapi-schema');
 const consoleOutputRenderer = require('./lib/output/console.js');
 const checkStyleRenderer = require('./lib/output/checkstyle.js');
 const junitRenderer = require('./lib/output/junit.js');
+const { outputToFileRenderer } = require('./lib/output/toFileRenderer.js');
 
-const getOutputRenderer = type => {
+const getOutputRenderer = (type, outputFile) => {
+    let renderer = consoleOutputRenderer;
+
     if(type === 'checkstyle') {
-        return checkStyleRenderer;
+        renderer = checkStyleRenderer;
+    } else if(type == 'junit') {
+        renderer =  junitRenderer;
     }
-    if(type == 'junit') {
-        return junitRenderer;
+
+    if(type !== 'console' && outputFile) {
+        return outputToFileRenderer(renderer, outputFile);
     }
 
     return consoleOutputRenderer;
@@ -29,7 +35,7 @@ const command = async (specFile, cmd) => {
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
     const rulesets = config.get('lint:rules', []);
     const skip = config.get('lint:skip', []);
-    const outputRenderer = getOutputRenderer(config.get('lint:output'));
+    const outputRenderer = getOutputRenderer(config.get('lint:output'), config.get('lint:outputFile'));
 
     rules.init({
         skip

--- a/lint.js
+++ b/lint.js
@@ -9,8 +9,13 @@ const rules = require('./lib/rules.js');
 const validator = require('oas-validator');
 const fromJsonSchema = require('json-schema-to-openapi-schema');
 const consoleOutputRenderer = require('./lib/output/console.js');
+const checkStyleRenderer = require('./lib/output/checkstyle.js');
 
 const getOutputRenderer = type => {
+    if(type === 'checkstyle') {
+        return checkStyleRenderer;
+    }
+
     return consoleOutputRenderer;
 }
 

--- a/lint.js
+++ b/lint.js
@@ -10,10 +10,14 @@ const validator = require('oas-validator');
 const fromJsonSchema = require('json-schema-to-openapi-schema');
 const consoleOutputRenderer = require('./lib/output/console.js');
 const checkStyleRenderer = require('./lib/output/checkstyle.js');
+const junitRenderer = require('./lib/output/junit.js');
 
 const getOutputRenderer = type => {
     if(type === 'checkstyle') {
         return checkStyleRenderer;
+    }
+    if(type == 'junit') {
+        return junitRenderer;
     }
 
     return consoleOutputRenderer;

--- a/lint.js
+++ b/lint.js
@@ -8,69 +8,19 @@ const linter = require('oas-linter');
 const rules = require('./lib/rules.js');
 const validator = require('oas-validator');
 const fromJsonSchema = require('json-schema-to-openapi-schema');
+const consoleOutputRenderer = require('./lib/output/console.js');
 
-const colors = process.env.NODE_DISABLE_COLORS ? {} : {
-    red: '\x1b[31m',
-    green: '\x1b[32m',
-    yellow: '\x1b[33m',
-    blue: '\x1b[34m',
-    magenta: '\x1b[35m',
-    cyan: '\x1b[36m',
-    white: '\x1b[37m',
-    reset: '\x1b[0m'
-};
-
-const formatSchemaError = (err, context) => {
-    const pointer = context.pop();
-    let output = `
-${colors.yellow + pointer}
-`;
-    
-    if (err.name === 'AssertionError' || err.error.name === 'AssertionError') {
-        output += colors.reset + truncateLongMessages(err.message);
-    }
-    else if (err instanceof validator.CLIError) {
-        output += colors.reset + err.message;
-    }
-    else {
-        output += colors.red + err.stack;
-    }
-    return output;
-}
-
-const truncateLongMessages = message => {
-    let lines = message.split('\n');
-    if (lines.length > 6) {
-        lines = lines.slice(0, 5).concat(
-            ['  ... snip ...'],
-            lines.slice(-1)
-        );
-    }
-    return lines.join('\n');
-}
-
-const formatLintResults = lintResults => {
-    let output = '';
-    lintResults.forEach(result => {
-        const { rule, error, pointer } = result;
-
-        output += `
-${colors.yellow + pointer} ${colors.cyan} R: ${rule.name} ${colors.white} D: ${rule.description}
-${colors.reset + truncateLongMessages(error.message)}
-
-More information: ${rule.url}#${rule.name}
-`;
-    });
-
-    return output;
+const getOutputRenderer = type => {
+    return consoleOutputRenderer;
 }
 
 const command = async (specFile, cmd) => {
-    config.init(cmd);
+    config.init(cmd);    
     const jsonSchema = config.get('jsonSchema');
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
     const rulesets = config.get('lint:rules', []);
     const skip = config.get('lint:skip', []);
+    const outputRenderer = getOutputRenderer(config.get('lint:output'));
 
     rules.init({
         skip
@@ -87,26 +37,14 @@ const command = async (specFile, cmd) => {
         validator.validate(spec, buildValidatorOptions(skip, verbose), (err, _options) => {
             const { context, warnings, valid } = _options || err.options;
 
+            outputRenderer.render(err, warnings, valid, context, cmd.quiet);
+            
             if (err && valid === false) {
-                console.error(colors.red + 'Specification schema is invalid.' + colors.reset);
-                if (err.name === 'AssertionError') {
-                    console.error(formatSchemaError(err, context));
-                }
-
-                for (let linterResult of err.options.linterResults()) {
-                    console.error(formatSchemaError(linterResult, context));
-                }
                 return reject();
             }
 
             if (warnings.length) {
-                console.error(colors.red + 'Specification contains lint errors: ' + warnings.length + colors.reset);
-                console.warn(formatLintResults(warnings))
                 return reject();
-            }
-
-            if (!cmd.quiet) {
-                console.log(colors.green + 'Specification is valid, with 0 lint errors' + colors.reset)
             }
 
             return resolve();

--- a/lint.js
+++ b/lint.js
@@ -41,18 +41,19 @@ const command = async (specFile, cmd) => {
         skip
     });
     await loader.loadRulesets(rulesets, { verbose });
-    linter.applyRules(rules.getRules());
+    const rulesToApply = rules.getRules();
+    linter.applyRules(rulesToApply);
 
     const spec = await loader.readOrError(
         specFile,
         buildLoaderOptions(jsonSchema, verbose)
     );
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {        
         validator.validate(spec, buildValidatorOptions(skip, verbose), (err, _options) => {
             const { context, warnings, valid } = _options || err.options;
 
-            outputRenderer.render(err, warnings, valid, context, cmd.quiet);
+            outputRenderer.render(err, warnings, valid, context, cmd.quiet, linter.getRules().rules.length);
             
             if (err && valid === false) {
                 return reject();

--- a/speccy.js
+++ b/speccy.js
@@ -32,6 +32,7 @@ program
     .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
+    .option('-o, --output <format>', 'output [format], supports: console (default: console)', 'console')
     .action((specFile, cmd) => {
         lint.command(specFile, cmd)
             .then(() => { process.exit(0) })

--- a/speccy.js
+++ b/speccy.js
@@ -32,7 +32,7 @@ program
     .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
-    .option('-o, --output <format>', 'output [format], supports: console (default: console)', 'console')
+    .option('-o, --output <format>', 'output [format], supports: console, checkstyle, junit (default: console)', 'console')
     .action((specFile, cmd) => {
         lint.command(specFile, cmd)
             .then(() => { process.exit(0) })

--- a/speccy.js
+++ b/speccy.js
@@ -33,6 +33,7 @@ program
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
     .option('-o, --output <format>', 'output [format], supports: console, checkstyle, junit (default: console)', 'console')
+    .option('-f, --outputFile <outputFileName>', 'path to write the output to (optional). This option is only applicable to output type checkstyle or junit')
     .action((specFile, cmd) => {
         lint.command(specFile, cmd)
             .then(() => { process.exit(0) })


### PR DESCRIPTION
This PR introduces two new output formats for the `lint` command:

- [checkstyle](https://github.com/checkstyle/checkstyle)
- [JUnit](https://github.com/junit-team/junit5)

These formats can be selected by providing a `-o junit` argument to `speccy lint`.

Console output remains the default but has been moved to a separate renderer as well to remove the concern for output rendering form the lint command.

For all output types except `console` there is an additional argument, `-f`, to specify the file the output should be written to:

```bash
user@host$> speccy lint -o junit -f validation-results.xml spec-to-validate.json
```

This writes a JUnit result file to `validation-results.xml` which allows the build system to pick this up and add to the build results.