### PR TITLE
Support setting yaml version to 1.1

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ class Config {
         this.load(configFile, {
             quiet: args.quiet,
             jsonSchema: args.jsonSchema,
+            yamlVersion: args.yamlVersion,
             verbose: args.verbose,
             // Command specific options
             lint: {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -100,7 +100,7 @@ const readOrError = async (file, options = {}) => {
 }
 
 const recursivelyLoadRulesets = async (ruleset, loadedRulesets, options) => {
-    const { verbose } = options;
+    const { verbose, yamlVersion } = options;
 
     let text;
     // If the ruleset looks like a HTTP URL
@@ -119,7 +119,8 @@ const recursivelyLoadRulesets = async (ruleset, loadedRulesets, options) => {
     }
 
     try {
-        const data = yaml.parse(text, { prettyErrors: true });
+        // defaults to undefined
+        const data = yaml.parse(text, { prettyErrors: true, version: yamlVersion || '1.2' });
 
         loadedRulesets.push(ruleset);
 
@@ -151,9 +152,9 @@ async function asyncMap(array, callback) {
 }
 
 const loadRulesets = async (loadFiles, options = {}) => {
-    const { verbose } = options;
+    const { verbose, yamlVersion } = options;
     const rulesetList = (loadFiles && loadFiles.length > 0 ? loadFiles : ['default']);
-    const allDependencies = await asyncMap(rulesetList, ruleset => recursivelyLoadRulesets(ruleset, [], { verbose }));
+    const allDependencies = await asyncMap(rulesetList, ruleset => recursivelyLoadRulesets(ruleset, [], { verbose, yamlVersion }));
     const flatDependencies = [].concat(...allDependencies);
     // Unique copy of the array
     return [...(new Set(flatDependencies))];
@@ -178,8 +179,9 @@ const loadSpec = async (source, options = {}) => {
     return await readSpecFile(source, options)
         .then(content => {
             try {
-                return yaml.parse(content, { prettyErrors: true } );
+                return yaml.parse(content, { prettyErrors: true, version: options.yamlVersion || '1.2' } );
             } catch (err) {
+                console.log(err);
                 throw new ReadError("\nLine: " + err.linePos.start.line + ", col: " + err.linePos.start.col + " " + err.message);
             }
         }, err => {

--- a/lint.js
+++ b/lint.js
@@ -68,6 +68,7 @@ More information: ${rule.url}#${rule.name}
 const command = async (specFile, cmd) => {
     config.init(cmd);
     const jsonSchema = config.get('jsonSchema');
+    const yamlVersion = config.get('yamlVersion');
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
     const rulesets = config.get('lint:rules', []);
     const skip = config.get('lint:skip', []);
@@ -75,12 +76,12 @@ const command = async (specFile, cmd) => {
     rules.init({
         skip
     });
-    await loader.loadRulesets(rulesets, { verbose });
+    await loader.loadRulesets(rulesets, { verbose, yamlVersion });
     linter.applyRules(rules.getRules());
 
     const spec = await loader.readOrError(
         specFile,
-        buildLoaderOptions(jsonSchema, verbose)
+        buildLoaderOptions(jsonSchema, verbose, yamlVersion)
     );
 
     return new Promise((resolve, reject) => {
@@ -114,7 +115,7 @@ const command = async (specFile, cmd) => {
     });
 };
 
-const buildLoaderOptions = (jsonSchema, verbose) => {
+const buildLoaderOptions = (jsonSchema, verbose, yamlVersion) => {
     const options = {
         filters: [],
         resolve: true,
@@ -124,6 +125,7 @@ const buildLoaderOptions = (jsonSchema, verbose) => {
     if (jsonSchema) {
         options.filters.push(fromJsonSchema);
     }
+    if (yamlVersion) options.yamlVersion = yamlVersion;
 
     return options;
 }

--- a/resolve.js
+++ b/resolve.js
@@ -14,12 +14,15 @@ const command = async (file, cmd) => {
     const output = config.get('resolve:output');
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
     const internalRefs = config.get('resolve:internalRefs');
+    const yamlVersion = config.get('yamlVersion');
+    const options = yamlVersion ? { version: yamlVersion } : undefined;
 
     const spec = await loader.readOrError(
         file,
-        buildLoaderOptions(jsonSchema, verbose, internalRefs)
+        buildLoaderOptions(jsonSchema, verbose, internalRefs, yamlVersion)
     );
-    const content = yaml.stringify(spec);
+
+    const content = yaml.stringify(spec, options);
 
     return new Promise((resolve, reject) => {
         if (output) {
@@ -41,7 +44,7 @@ const command = async (file, cmd) => {
     });
 };
 
-const buildLoaderOptions = (jsonSchema, verbose, internalRefs) => {
+const buildLoaderOptions = (jsonSchema, verbose, internalRefs, yamlVersion) => {
     const options = {
         resolve: true,
         cache: [],
@@ -53,6 +56,7 @@ const buildLoaderOptions = (jsonSchema, verbose, internalRefs) => {
         verbose,
     };
     if (jsonSchema) options.filters.push(fromJsonSchema);
+    if (yamlVersion) options.yamlVersion = yamlVersion;
     if (internalRefs) options.resolveInternal = true;
     
     return options;

--- a/serve.js
+++ b/serve.js
@@ -37,6 +37,7 @@ const launchServer = (app, port, specFile, { verbose }) => {
 const command = async (specFile, cmd) => {
     config.init(cmd);
     const jsonSchema = config.get('jsonSchema');
+    const yamlVersion = config.get('yamlVersion');
     const verbose = config.get('quiet') ? 0 : config.get('verbose', 1);
     const port = config.get('serve:port', DEFAULT_PORT);
 
@@ -46,7 +47,7 @@ const command = async (specFile, cmd) => {
 
     const spec = await loader.readOrError(
         specFile,
-        buildLoaderOptions(jsonSchema, verbose)
+        buildLoaderOptions(jsonSchema, verbose, yamlVersion)
     );
 
     app.use('/assets/redoc', express.static(bundleDir));
@@ -61,13 +62,14 @@ const command = async (specFile, cmd) => {
     launchServer(app, port, specFile, { verbose });
 }
 
-const buildLoaderOptions = (jsonSchema, verbose) => {
+const buildLoaderOptions = (jsonSchema, verbose, yamlVersion) => {
     const options = {
         resolve: true,
         verbose,
         filters: [],
     };
     if (jsonSchema) options.filters.push(fromJsonSchema);
+    if (yamlVersion) options.yamlVersion = yamlVersion
     return options;
 }
 

--- a/speccy.js
+++ b/speccy.js
@@ -31,6 +31,7 @@ program
     .option('-r, --rules [ruleFile]', 'provide multiple rules files', collect, [])
     .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-y, --yaml-version [1.1 or 1.2]', 'set to 1.1 or 1.2 to pass through to yaml.parse and yaml.stringify, defaults to 1.2')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
     .action((specFile, cmd) => {
         lint.command(specFile, cmd)
@@ -49,6 +50,7 @@ program
     .option('-o, --output <file>', 'file to output to')
     .option('-q, --quiet', 'reduce verbosity')
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-y, --yaml-version [1.1 or 1.2]', 'set to 1.1 or 1.2 to pass through to yaml.parse and yaml.stringify, defaults to 1.2')
     .option('-i, --internal-refs', 'resolve internal references (default: false)')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
     .action((specFile, cmd) => {
@@ -68,6 +70,7 @@ program
     .option('-p, --port [value]', 'port on which the server will listen (default: 5000)')
     .option('-q, --quiet', 'reduce verbosity')
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
+    .option('-y, --yaml-version [1.1 or 1.2]', 'set to 1.1 or 1.2 to pass through to yaml.parse and yaml.stringify, defaults to 1.2')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
     // TODO .option('-w, --watch', 'reloading browser on spec file changes')
     .action((specFile, cmd) => {


### PR DESCRIPTION
hi! thanks for making speccy!

for this PR, the tests pass, and this would be nice to have because of the following issues i've also had:

https://github.com/swagger-api/swagger-ui/issues/5061
https://github.com/Mermade/oas-kit/issues/169#issuecomment-516769823
https://github.com/eemeli/yaml/issues/117

in a nutshell, i want to compile my yaml into a mega yaml using speccy (along with lint), but when my example strings are formatted like so: `"2016-09-08"`, the resulting mega yaml removes the quotes and translates them to simply `2016-09-08`. this is because the underlying `yaml` package parses yaml v1.1 (leaves quotes) spec differently from yaml v1.2 spec (removes quotes).

[quoting eemeli from the npm `yaml` package](https://github.com/eemeli/yaml/issues/117#issuecomment-524528432):
> The `yaml` stringifier verifies that its output will also be parsed to the same type as its input; this is why the string `"1"` gets stringified as `"1"`, rather than just `1`. What's happening here with `"2012-10-12"` is that the re-parsing test is defaulting to use the YAML core schema, which does not include timestamps as a data type, and hence allows the default unquoted style to be used.

the issue is most easily resolved by using an older, less "smart" spec (1.1) of yaml where the parser doesn't attempt to turn a string into its unquoted form. longer term, you guys might want to consider being more in control of your document parsing and stringifying by using the Document api provided by the `yaml` npm package, as opposed to just using the plain parse/stringify functions. or just maybe allow users to use a pass through options object or something, i dunno.

i would like to use 1.2, but i don't see and easy way to do that and get what i need quickly without a lot of work. this is a pretty quick and easy solution for my needs and I hope you'll accept it!

thanks,
Josh