### PR TITLE
chore(package.json): update redoc for npm audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2327,9 +2327,9 @@
       }
     },
     "dompurify": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.11.tgz",
-      "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
+      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3562,9 +3562,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5261,9 +5261,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.sortby": {
@@ -5467,9 +5467,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -5497,17 +5497,17 @@
       }
     },
     "mobx-react": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.1.1.tgz",
-      "integrity": "sha512-hjACWCTpxZf9Sv1YgWF/r6HS6Nsly1SYF22qBJeUE3j+FMfoptgjf8Zmcx2d6uzA07Cezwap5Cobq9QYa0MKUw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.1.4.tgz",
+      "integrity": "sha512-wzrJF1RflhyLh8ne4FJfMbG8ZgRFmZ62b4nbyhJzwQpAmrkSnSsAWG9mIff4ffV/Q7OU+uOYf7rXvSmiuUe4cw==",
       "requires": {
-        "mobx-react-lite": "1.4.0"
+        "mobx-react-lite": "^1.4.2"
       }
     },
     "mobx-react-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz",
-      "integrity": "sha512-5xCuus+QITQpzKOjAOIQ/YxNhOl/En+PlNJF+5QU4Qxn9gnNMJBbweAdEW3HnuVQbfqDYEUnkGs5hmkIIStehg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.0.tgz",
+      "integrity": "sha512-Ss8RLKKGn+QhKbfCHvQ4+RPEVKR8AnPW1wNyWzZAS3wYw7UP4FX6GdRn64sdOhrP646o/JtXbLuDuc4RH3Bqyg=="
     },
     "mock-stdin": {
       "version": "0.3.1",
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -6178,9 +6178,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -6355,9 +6355,9 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.10.tgz",
-      "integrity": "sha512-dX+ZUigxQijWLsKPnxc0khuCt2sYiZ1W59LgSBMOLeGSG3+HkknrTlnJu6BCNdhYxbEQkGvBsr7zXlNWYUIhAQ==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.15.tgz",
+      "integrity": "sha512-sgkN6g+tgPE6xZzD0Ysqll7KUFYJbMX0DrczT5OxD6S7hZlSnmqSC3ceudwCkiDd65ZTtm+Ayk4Y9k5xxCvpOw==",
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -6377,9 +6377,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -6441,34 +6441,34 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.12.tgz",
-      "integrity": "sha512-W4vZ3Xxcoy8GZsrWhhFwVFysCLziEDcu7R6rV28Z24HFl/WLCMxkC6t4a1orePY1p29BUqjFo4DIrK6v97RWpg==",
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.18.tgz",
+      "integrity": "sha512-GCbNbL37N8Kp+GrSzUVYuZzrZgelDnE6mLx8p/g65SnksrAQElHNqg1zoYSQlebNT2JqMPIfuyNElwlMDilCbg==",
       "requires": {
         "classnames": "^2.2.6",
         "decko": "^1.2.0",
-        "dompurify": "^1.0.11",
+        "dompurify": "^2.0.3",
         "eventemitter3": "^4.0.0",
         "json-pointer": "^0.6.0",
         "json-schema-ref-parser": "^6.1.0",
         "lunr": "2.3.6",
         "mark.js": "^8.11.1",
         "marked": "^0.7.0",
-        "memoize-one": "^5.0.5",
-        "mobx-react": "^6.1.1",
+        "memoize-one": "~5.0.5",
+        "mobx-react": "^6.1.3",
         "openapi-sampler": "1.0.0-beta.15",
         "perfect-scrollbar": "^1.4.0",
         "polished": "^3.4.1",
         "prismjs": "^1.17.1",
         "prop-types": "^15.7.2",
         "react-dropdown": "^1.6.4",
-        "react-hot-loader": "^4.12.10",
+        "react-hot-loader": "^4.12.14",
         "react-tabs": "^3.0.0",
-        "slugify": "^1.3.4",
+        "slugify": "^1.3.5",
         "stickyfill": "^1.1.1",
         "swagger2openapi": "^5.3.1",
         "tslib": "^1.10.0",
-        "uri-template-lite": "^19.4.0"
+        "url-template": "^2.0.8"
       }
     },
     "reftools": {
@@ -6795,9 +6795,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -6912,9 +6912,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
-      "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.5.tgz",
+      "integrity": "sha512-5VCnH7aS13b0UqWOs7Ef3E5rkhFe8Od+cp7wybFv5mv/sYSRkucZlJX0bamAJky7b2TTtGvrJBWVdpdEicsSrA=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7243,17 +7243,17 @@
           }
         },
         "better-ajv-errors": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.4.tgz",
-          "integrity": "sha512-+spBhtcCzovXWeHpt5dGylFsn3p5l9w+KcUqh/b4MFdLV+q1sT1olxD9izvwi0D3WuP06eVgeZAGLtxtTnUIDg==",
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.7.tgz",
+          "integrity": "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/runtime": "^7.0.0",
             "chalk": "^2.4.1",
-            "core-js": "^2.5.7",
+            "core-js": "^3.2.1",
             "json-to-ast": "^2.0.3",
             "jsonpointer": "^4.0.1",
-            "leven": "^2.1.0"
+            "leven": "^3.1.0"
           }
         },
         "chalk": {
@@ -7267,9 +7267,14 @@
           }
         },
         "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.3.tgz",
+          "integrity": "sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow=="
+        },
+        "leven": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+          "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
         },
         "oas-resolver": {
           "version": "2.2.5",
@@ -7313,6 +7318,16 @@
                 "jsonpointer": "^4.0.1",
                 "leven": "^2.1.0"
               }
+            },
+            "core-js": {
+              "version": "2.6.10",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+              "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+            },
+            "leven": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+              "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
             }
           }
         },
@@ -7521,16 +7536,23 @@
       }
     },
     "uglify-js": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-      "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+      "integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7541,38 +7563,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unpipe": {
@@ -7620,16 +7619,16 @@
         }
       }
     },
-    "uri-template-lite": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/uri-template-lite/-/uri-template-lite-19.4.0.tgz",
-      "integrity": "sha512-VY8dgwyMwnCztkzhq0cA/YhNmO+YZqow//5FdmgE2fZU/JPi+U0rPL7MRDi0F+Ch4vJ7nYidWzeWAeY7uywe9g=="
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,7 +1706,8 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2312,11 +2313,6 @@
       "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
       "dev": true
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2355,7 +2351,8 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2728,7 +2725,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2825,9 +2823,9 @@
       }
     },
     "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3514,15 +3512,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3562,9 +3551,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.0.tgz",
+      "integrity": "sha512-PaZ6G6nYzfJ0Hd1WIhOpsnUPWh1R0Pg//r4wEYOtzG65c2V8RJQ/++yYlVmuoQ7EMXcb4eri5+FB2XH1Lwed9g==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3664,14 +3653,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-      "requires": {
-        "react-is": "^16.7.0"
       }
     },
     "home-or-tmp": {
@@ -5162,7 +5143,8 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -5244,6 +5226,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
       "requires": {
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
@@ -5288,9 +5271,9 @@
       }
     },
     "lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q=="
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -5374,9 +5357,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
-      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -5443,14 +5426,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5505,9 +5480,9 @@
       }
     },
     "mobx-react-lite": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.0.tgz",
-      "integrity": "sha512-Ss8RLKKGn+QhKbfCHvQ4+RPEVKR8AnPW1wNyWzZAS3wYw7UP4FX6GdRn64sdOhrP646o/JtXbLuDuc4RH3Bqyg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "mock-stdin": {
       "version": "0.3.1",
@@ -6170,17 +6145,17 @@
       "dev": true
     },
     "polished": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.4.1.tgz",
-      "integrity": "sha512-GflTnlP5rrpDoigjczEkS6Ye7NDA4sFvAnlr5hSDrEvjiVj97Xzev3hZlLi3UB27fpxyTS9rWU64VzVLWkG+mg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.4.2.tgz",
+      "integrity": "sha512-9Rch6iMZckABr6EFCLPZsxodeBpXMo9H4fRlfR/9VjMEyy5xpo1/WgXlJGgSjPyVhEZNycbW7UmYMNyWS5MI0g==",
       "requires": {
-        "@babel/runtime": "^7.4.5"
+        "@babel/runtime": "^7.6.3"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.0.tgz",
+          "integrity": "sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -6240,9 +6215,9 @@
       }
     },
     "prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.18.0.tgz",
+      "integrity": "sha512-N0r3i/Cto516V8+GKKamhsPVZSFcO0TMUBtIDW6uq6BVqoC3FNtZVZ+cmH16N2XtGQlgRN+sFUTjOdCsEP51qw==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -6252,11 +6227,6 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -6354,42 +6324,15 @@
         "classnames": "^2.2.3"
       }
     },
-    "react-hot-loader": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.15.tgz",
-      "integrity": "sha512-sgkN6g+tgPE6xZzD0Ysqll7KUFYJbMX0DrczT5OxD6S7hZlSnmqSC3ceudwCkiDd65ZTtm+Ayk4Y9k5xxCvpOw==",
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        }
-      }
-    },
     "react-is": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
-      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
     "react-tabs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.0.0.tgz",
-      "integrity": "sha512-z90cDIb+5V7MzjXFHq1VLxYiMH7dDQWan7mXSw6BWQtw+9pYAnq/fEDvsPaXNyevYitvLetdW87C61uu27JVMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.0.tgz",
+      "integrity": "sha512-9RKc77HCPsjQDVPyZEw37g3JPtg26oSQ9o4mtaVXjJuLedDX5+TQcE+MRNKR+4aO3GMAY4YslCePGG1//MQ3Jg==",
       "requires": {
         "classnames": "^2.2.0",
         "prop-types": "^15.5.0"
@@ -6441,30 +6384,29 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.18.tgz",
-      "integrity": "sha512-GCbNbL37N8Kp+GrSzUVYuZzrZgelDnE6mLx8p/g65SnksrAQElHNqg1zoYSQlebNT2JqMPIfuyNElwlMDilCbg==",
+      "version": "2.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.20.tgz",
+      "integrity": "sha512-nk+6aiBTRatUJ4oc+K+o/oXSEeh0Q7P9qRD7UibRCANM5ymdu4mpoMlDAHpU7iYvwejKeSuQdxfOaxTSsRTCSw==",
       "requires": {
         "classnames": "^2.2.6",
         "decko": "^1.2.0",
-        "dompurify": "^2.0.3",
+        "dompurify": "^2.0.7",
         "eventemitter3": "^4.0.0",
         "json-pointer": "^0.6.0",
         "json-schema-ref-parser": "^6.1.0",
-        "lunr": "2.3.6",
+        "lunr": "2.3.8",
         "mark.js": "^8.11.1",
         "marked": "^0.7.0",
-        "memoize-one": "~5.0.5",
-        "mobx-react": "^6.1.3",
+        "memoize-one": "~5.1.1",
+        "mobx-react": "^6.1.4",
         "openapi-sampler": "1.0.0-beta.15",
         "perfect-scrollbar": "^1.4.0",
-        "polished": "^3.4.1",
+        "polished": "^3.4.2",
         "prismjs": "^1.17.1",
         "prop-types": "^15.7.2",
         "react-dropdown": "^1.6.4",
-        "react-hot-loader": "^4.12.14",
         "react-tabs": "^3.0.0",
-        "slugify": "^1.3.5",
+        "slugify": "^1.3.6",
         "stickyfill": "^1.1.1",
         "swagger2openapi": "^5.3.1",
         "tslib": "^1.10.0",
@@ -6822,11 +6764,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -6912,9 +6849,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.5.tgz",
-      "integrity": "sha512-5VCnH7aS13b0UqWOs7Ef3E5rkhFe8Od+cp7wybFv5mv/sYSRkucZlJX0bamAJky7b2TTtGvrJBWVdpdEicsSrA=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+      "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7217,20 +7154,20 @@
       "dev": true
     },
     "swagger2openapi": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.3.1.tgz",
-      "integrity": "sha512-2EIs1gJs9LH4NjrxHPJs6N0Kh9pg66He+H9gIcfn1Q9dvdqPPVTC2NRdXalqT+98rIoV9kSfAtNBD4ASC0Q1mg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.3.2.tgz",
+      "integrity": "sha512-tcZtfuhy6XWEF7/wqKnlh1u5xa3nyLrfKb9xHg1JxU9z88SdR8JygiEOOkpVJTC9/bjwZwf2TQt3YXJYMGmYkQ==",
       "requires": {
         "better-ajv-errors": "^0.6.1",
         "call-me-maybe": "^1.0.1",
         "node-fetch-h2": "^2.3.0",
         "node-readfiles": "^0.2.0",
         "oas-kit-common": "^1.0.7",
-        "oas-resolver": "^2.2.5",
+        "oas-resolver": "^2.2.6",
         "oas-schema-walker": "^1.1.2",
-        "oas-validator": "^3.3.1",
-        "reftools": "^1.0.8",
-        "yaml": "^1.3.1",
+        "oas-validator": "^3.3.2",
+        "reftools": "^1.0.9",
+        "yaml": "^1.7.2",
         "yargs": "^12.0.5"
       },
       "dependencies": {
@@ -7267,42 +7204,51 @@
           }
         },
         "core-js": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.3.tgz",
-          "integrity": "sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow=="
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
+          "integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ=="
         },
         "leven": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
           "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
         },
+        "oas-linter": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.0.2.tgz",
+          "integrity": "sha512-E2bpo6/x/q1dYCcsqs8yCvp+lYBaODNnxewgtDIT4FhaHjB3u/0DpRl3RNk23SLeaUn4F3qqbczrkK8FXWrYNQ==",
+          "requires": {
+            "should": "^13.2.1",
+            "yaml": "^1.7.2"
+          }
+        },
         "oas-resolver": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.2.5.tgz",
-          "integrity": "sha512-AwARII3hmdXtDAGccvjVsRLked0PNJycIG/koD6lYoGspJjxnQ3a8AmDgp7kHYnG148zusfsl8GM0cfwGmd7EA==",
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.2.6.tgz",
+          "integrity": "sha512-8Zrgf3dEoQOGSuRgi2ifZmVauW/TE+ev10IgeNgUWylNz10quCkxFLyLfGobEiMQm/EoLQFoQ7bK4R31tJefdA==",
           "requires": {
             "node-fetch-h2": "^2.3.0",
             "oas-kit-common": "^1.0.7",
-            "reftools": "^1.0.8",
-            "yaml": "^1.3.1",
+            "reftools": "^1.0.9",
+            "yaml": "^1.7.2",
             "yargs": "^12.0.5"
           }
         },
         "oas-validator": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.3.1.tgz",
-          "integrity": "sha512-WFKafxpH2KrxHG6drJiJ7M0mzGZER3XDkLtbeX8z9YNR4JvCMDlhQL7J2i+rnCxyVC8riRZGGeZpxQ0000w2HA==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.3.2.tgz",
+          "integrity": "sha512-4RaTkDUg6rDntFzmOb8LS6I5EVj7VmdpjQWQW7haxR+KE0y5xTVRtzL9a5Db0SK2TsR06mvAFKmrxo6knXapcg==",
           "requires": {
             "ajv": "^5.5.2",
             "better-ajv-errors": "^0.5.2",
             "call-me-maybe": "^1.0.1",
             "oas-kit-common": "^1.0.7",
-            "oas-linter": "^3.0.1",
-            "oas-resolver": "^2.2.5",
+            "oas-linter": "^3.0.2",
+            "oas-resolver": "^2.2.6",
             "oas-schema-walker": "^1.1.2",
-            "reftools": "^1.0.8",
+            "reftools": "^1.0.9",
             "should": "^13.2.1",
-            "yaml": "^1.3.1"
+            "yaml": "^1.7.2"
           },
           "dependencies": {
             "better-ajv-errors": {
@@ -7320,9 +7266,9 @@
               }
             },
             "core-js": {
-              "version": "2.6.10",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-              "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+              "version": "2.6.11",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+              "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
             },
             "leven": {
               "version": "2.1.0",
@@ -7332,9 +7278,14 @@
           }
         },
         "reftools": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.8.tgz",
-          "integrity": "sha512-hERpM8J+L0q8dzKFh/QqcLlKZYmTgzGZM7m8b1ptS66eg4NA/iMPm7GNw3TKZ876ndVjGpiLt0BCIfAWsUgwGg=="
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.9.tgz",
+          "integrity": "sha512-agiXf3PZ4WZTNvc1a+YvWoy8tOWeikSSA/AT0CRmObbSYi+mPkwHj+SmD6JzdU3WkZFi4lvXDUaFY+vcNYCUdA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         },
         "supports-color": {
           "version": "5.5.0",
@@ -7342,6 +7293,24 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "yaml": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+          "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+          "requires": {
+            "@babel/runtime": "^7.6.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.8.0",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.0.tgz",
+              "integrity": "sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==",
+              "requires": {
+                "regenerator-runtime": "^0.13.2"
+              }
+            }
           }
         }
       }
@@ -7536,9 +7505,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-      "integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "oas-linter": "^3.0.0",
     "oas-resolver": "^2.2.4",
     "oas-validator": "^3.0.1",
-    "redoc": "^2.0.0-rc.18",
+    "redoc": "^2.0.0-rc.20",
     "yaml": "^1.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "oas-linter": "^3.0.0",
     "oas-resolver": "^2.2.4",
     "oas-validator": "^3.0.1",
-    "redoc": "v2.0.0-rc.12",
+    "redoc": "^2.0.0-rc.18",
     "yaml": "^1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of redoc used has a dependency on `dompurify` that has
security vulnerabilities described by `npm audit`.

When updating to the latest `redoc`, `npm audit` returns no vulnerabilities.

Running the test suite also shows no test failures with the `package-lock.json` changes.