### PR TITLE
Adding SARIF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Options:
   -s, --skip [ruleName]   provide multiple rules to skip
   -j, --json-schema       treat $ref like JSON Schema and convert to OpenAPI Schema Objects
   -v, --verbose           set verbosity (use multiple times to increase level)
+  -f, --format [format]   result format (sarif or default)
   -h, --help              output usage information
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Options:
   -s, --skip [ruleName]   provide multiple rules to skip
   -j, --json-schema       treat $ref like JSON Schema and convert to OpenAPI Schema Objects
   -v, --verbose           increase verbosity
+  -f, --format [format]   result format
   -h, --help              output usage information
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ class Config {
             lint: {
                 rules: this.notEmptyArray(args.rules),
                 skip: this.notEmptyArray(args.skip),
+                format: args.format,
             },
             resolve: {
                 output: args.output,

--- a/lint.js
+++ b/lint.js
@@ -99,7 +99,7 @@ const formatLintResultsAsSarif = (lintResults, specFile) => {
             newRule['helpUri'] = rule.url + "#" + rule.name;
             sarif['runs'][0]['tool']['driver']['rules'].push(newRule);
         }
-        const ruleIndex = sarif['runs'][0]['tool']['driver']['rules'].length - 1;
+        const ruleIndex = sarif['runs'][0]['tool']['driver']['rules'].findIndex(it => it.id === rule.name);
         var result = {
             'ruleId' : rule.name,
             'ruleIndex' : ruleIndex,

--- a/speccy.js
+++ b/speccy.js
@@ -32,6 +32,7 @@ program
     .option('-s, --skip [ruleName]', 'provide multiple rules to skip', collect, [])
     .option('-j, --json-schema', 'treat $ref like JSON Schema and convert to OpenAPI Schema Objects (default: false)')
     .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 1)
+    .option('-f, --format [format]', 'Result format, currently support sarif format and default format.')
     .action((specFile, cmd) => {
         lint.command(specFile, cmd)
             .then(() => { process.exit(0) })

--- a/templates/sarif_template.json
+++ b/templates/sarif_template.json
@@ -1,0 +1,49 @@
+{
+  "$schema":"https://www.schemastore.org/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version":"2.1.0",
+  "runs":[
+    {
+      "tool":{
+        "driver":{
+          "name":"Speccy",
+          "informationUri":"http://speccy.io/",
+          "version":"0.11.0",
+          "rules":[
+            {
+              "id":"info-contact",
+              "shortDescription":{
+                "text":"info object should contain contact object"
+              },
+              "helpUri": "https://speccy.io/rules/1-rulesets"
+            }
+          ]
+        }
+      },
+      "results":[
+        {
+          "ruleId":"info-contact",
+          "ruleIndex":0,
+          "message":{
+            "text":"#/info: expected Object { version: '1.0.0', title: 'Swagger 2.0 Without Scheme' } to have property contact"
+          },
+          "locations":[
+            {
+              "physicalLocation":{
+                "artifactLocation":{
+                  "uri":"no-contact.yaml",
+                  "uriBaseId":"ROOTPATH"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind":"utf16CodeUnits",
+      "originalUriBaseIds":{
+        "ROOTPATH":{
+          "uri":"file:///home/user/testopenapidir/"
+        }
+      }
+    }
+  ]
+}

--- a/test/integration/lint.test.js
+++ b/test/integration/lint.test.js
@@ -11,6 +11,14 @@ const commandConfig = {
     skip: []
 };
 
+const commandConfigSarif = {
+    quiet: false,
+    verbose: false,
+    rules: [],
+    skip: [],
+    format: 'sarif'
+};
+
 beforeEach(() => {
     jest.restoreAllMocks();
 });
@@ -73,6 +81,25 @@ describe('Lint command', () => {
                 expect(errorSpy).toBeCalledTimes(1);
                 expect(errorSpy.mock.calls[0][0]).toEqual('\x1b[31mSpecification contains lint errors: 1\x1b[0m');
                 expect(warnSpy.mock.calls[0][0]).toContain('info-contact');
+            });
+        });
+    });
+
+    describe('properly handles linter warnings with format SARIF', () => {
+        test('displays a linting error on missing contact field with format SARIF', () => {
+            expect.assertions(7);
+            const logSpy = jest.spyOn(console, 'log');
+            const warnSpy = jest.spyOn(console, 'warn');
+            const errorSpy = jest.spyOn(console, 'error');
+
+            return lint.command('./test/fixtures/integration/missing-contact.yaml', commandConfigSarif).catch(() => {
+                expect(logSpy).toBeCalledTimes(0);
+                expect(warnSpy).toBeCalledTimes(1);
+                expect(errorSpy).toBeCalledTimes(1);
+                expect(errorSpy.mock.calls[0][0]).toEqual('\x1b[31mSpecification contains lint errors: 1\x1b[0m');
+                expect(warnSpy.mock.calls[0][0]).toContain('"tool":{"driver":{"name":"Speccy","informationUri":"http://speccy.io/"');
+                expect(warnSpy.mock.calls[0][0]).toContain('"results":[{"ruleId":"info-contact"');
+                expect(warnSpy.mock.calls[0][0]).toContain('"helpUri":"https://speccy.io/rules/1-rulesets#info-contact"');
             });
         });
     });


### PR DESCRIPTION
Add support for output in SARIF format.

Hello! We are interested in adding support for output in the open-standard SARIF format to speccy. SARIF support is required to integrate it in [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning). Doing so would make it available to every repo in GitHub and could result in increase in user base.

More about SARIF here:
[What is SARIF?](https://github.com/microsoft/sarif-tutorials/blob/main/docs/1-Introduction.md#what-is-sarif)
[Why SARIF?](https://github.com/microsoft/sarif-tutorials/blob/main/docs/1-Introduction.md#why-sarif)

After the support for SARIF output is added to the tool and published a new version, we will work on creating a starter workflow to make it available as a GitHub code scanner.
